### PR TITLE
[Fix] #81 - 스토리북 타입 경로 및 아이콘 중복 선언으로 인한 빌드 오류 수정

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       autoprefixer:
         specifier: ^10.4.24
         version: 10.4.24(postcss@8.5.6)
-      baseline-browser-mapping:
-        specifier: ^2.10.0
-        version: 2.10.0
       eslint:
         specifier: ^9.39.2
         version: 9.39.2(jiti@2.6.1)
@@ -818,56 +815,67 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
@@ -1022,24 +1030,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2089,24 +2101,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/src/shared/ui/avatars/avatars.stories.tsx
+++ b/src/shared/ui/avatars/avatars.stories.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { Avatar, AvatarGroup, type AvatarProps } from "./avatars";
 

--- a/src/shared/ui/empty_states/empty-states.stories.tsx
+++ b/src/shared/ui/empty_states/empty-states.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { EmptyState } from "./empty-states";
 
 const meta = {

--- a/src/shared/ui/empty_states/empty-states.tsx
+++ b/src/shared/ui/empty_states/empty-states.tsx
@@ -1,6 +1,13 @@
 import React from "react";
 // 1. 공통 아이콘 Import 추가
-import { FileTextIcon, SearchIcon, BellIcon, AlertCircleIcon, LockIcon, ClockIcon } from "../icons";
+import {
+  FileTextAltIcon,
+  SearchIcon,
+  BellIcon,
+  AlertCircleIcon,
+  LockIcon,
+  ClockIcon,
+} from "../icons";
 import { Button } from "../button/button";
 
 // ----------------------------------------------------------------------
@@ -44,7 +51,7 @@ type VariantConfig = {
 const VARIANT_MAP: Record<EmptyStateVariant, VariantConfig> = {
   "no-content": {
     title: "아직 게시물이 없습니다",
-    icon: <FileTextIcon className="w-full h-full" />,
+    icon: <FileTextAltIcon className="w-full h-full" />,
     iconColorClass: "text-[color:var(--color-primary-200,#B3D1F7)]",
   },
   "no-results": {

--- a/src/shared/ui/file-uploader/file-uploader.tsx
+++ b/src/shared/ui/file-uploader/file-uploader.tsx
@@ -1,5 +1,5 @@
 import React, { useRef, useState } from "react";
-import { UploadIcon, ImageIcon, XIcon, FileTextIcon } from "@/shared/ui/icons";
+import { UploadIcon, ImageIcon, XIcon, FileTextAltIcon } from "@/shared/ui/icons";
 import { Button } from "@/shared/ui/button/button";
 
 // --- Types ---
@@ -156,7 +156,7 @@ export const FileListItem = ({ file, onRemove, className }: FileListItemProps) =
     >
       <div className="flex items-center gap-3">
         <div className="text-[var(--color-gray-400,#999)]">
-          {file.type?.includes("image") ? <ImageIcon size={20} /> : <FileTextIcon size={20} />}
+          {file.type?.includes("image") ? <ImageIcon size={20} /> : <FileTextAltIcon size={20} />}
         </div>
         <div>
           <p className="text-[14px] font-medium text-[var(--color-gray-800,#333)] truncate max-w-[200px]">

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -479,8 +479,8 @@ export const UserSolidIcon: React.FC<IconProps> = ({ size = 24, ...props }) => (
   </svg>
 );
 
-// File Text 아이콘 (Empty States 컴포넌트 사용)
-export const FileTextIcon: React.FC<IconProps> = ({ size = 24, ...props }) => (
+// File Text 아이콘 (Empty States 전용 스타일)
+export const FileTextAltIcon: React.FC<IconProps> = ({ size = 24, ...props }) => (
   <svg
     width={size}
     height={size}


### PR DESCRIPTION
## 🔎 What is this PR?
다음 오류를 해결했습니다.

- 사용하지 않는 React import
- @storybook/react 타입 경로 불일치
- FileTextIcon 중복 선언

---

## 📝 Changes

1. avatars.stories.tsx
    - 사용하지 않는 React import 제거
2. empty-states.stories.tsx
    - Storybook 타입 import를 @storybook/react-vite로 통일
3. index.tsx
    - 중복 선언된 FileTextIcon 중 두 번째 선언명을 FileTextAltIcon으로 변경
4. pnpm-lock.yaml
    - lock 메타데이터 갱신 반영(libc 조건 포함)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated naming conventions for an icon component to enhance clarity and better reflect its usage in Empty States
  * Enhanced Storybook TypeScript configuration imports for improved build compatibility and optimized development workflows
  * Streamlined component story files by removing unused imports, reducing overall code complexity and improving maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->