### PR TITLE
[Fix] #92 - PostCard 컴포넌트 피그마 기준 QA 반영

### DIFF
--- a/src/shared/ui/card/card.stories.tsx
+++ b/src/shared/ui/card/card.stories.tsx
@@ -34,10 +34,7 @@ export const PostCard: Story = {
   args: {
     variant: "post",
     thumbnail: storyDefaultImage,
-    category: {
-      label: "기술",
-      color: "#4F46E5",
-    },
+    tags: ["React", "Next.js", "TypeScript"],
     title: "React Server Components 이해하기",
     description:
       "새로운 React Server Components에 대한 깊이 있는 탐구와 애플리케이션 성능 향상 방법을 알아봅니다.",

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { Button } from "../button";
 
 export type CardVariant = "post" | "profile" | "simple" | "featured";
@@ -8,11 +9,6 @@ export type SimpleCardVariant = "default" | "bordered" | "elevated";
 interface BaseCardProps {
   className?: string;
   onClick?: () => void;
-}
-
-interface CategoryBadge {
-  label: string;
-  color?: string;
 }
 
 interface Author {
@@ -34,14 +30,14 @@ interface ProfileStats {
 // 개별 카드 타입 정의
 interface PostCardSpecificProps {
   variant: "post";
+  href?: string;
   thumbnail?: string;
-  category?: CategoryBadge;
+  tags?: string[];
   title: string;
   description: string;
   author: Author;
   date: string;
   stats: PostStats;
-  isSelected?: boolean;
 }
 
 interface ProfileCardSpecificProps {
@@ -101,90 +97,90 @@ Card.displayName = "Card";
 const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { variant: "post" }>>(
   (props, ref) => {
     const {
+      href,
       thumbnail,
-      category,
+      tags,
       title,
       description,
       author,
       date,
       stats,
-      isSelected = false,
       className = "",
       onClick,
     } = props;
 
-    const baseClasses =
-      "w-full min-w-[280px] max-w-[360px] p-6 bg-white border rounded-xl transition-all duration-200 ease-out";
+    const wrapperClasses = `flex flex-col group ${onClick ? "cursor-pointer" : ""} ${className}`;
 
-    const stateClasses = isSelected
-      ? "bg-[var(--color-primary-50)] border-[var(--color-primary-800)] shadow-[0_4px_12px_rgba(0,74,156,0.12)]"
-      : "border-[var(--color-gray-200)] shadow-[0_2px_8px_rgba(0,0,0,0.04)] hover:border-[var(--color-primary-200)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.08)] hover:-translate-y-0.5";
+    const content = (
+      <>
+        {thumbnail && (
+          <div className="relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden">
+            <img
+              src={typeof thumbnail === "string" ? thumbnail : (thumbnail as { src: string }).src}
+              alt={title}
+              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+            />
+          </div>
+        )}
 
-    const cursorClass = onClick ? "cursor-pointer" : "";
+        <div className="bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 rounded-b-xl">
+          {tags && tags.length > 0 && (
+            <div className="flex gap-2 flex-wrap">
+              {tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="border border-[color:var(--color-primary-800,#003876)] text-[color:var(--color-primary-800,#003876)] text-[12px] font-medium leading-[1.33] tracking-[-0.3px] px-3 py-1 rounded-xl"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
-      if (!onClick) return;
-      if (event.key === "Enter" || event.key === " ") {
-        event.preventDefault();
-        onClick();
-      }
-    };
+          <h3 className="text-[color:var(--color-gray-800,#333)] text-[20px] font-semibold leading-[1.4] tracking-[-0.5px] line-clamp-1">
+            {title}
+          </h3>
+
+          <p className="text-[color:var(--color-gray-600,#666)] text-[14px] leading-[1.43] tracking-[-0.35px] line-clamp-1">
+            {description}
+          </p>
+
+          <div className="flex items-center gap-1">
+            <span className="text-[color:var(--color-gray-500,#808080)] text-[12px] leading-[1.33] tracking-[-0.3px]">
+              {author.name}
+            </span>
+            <div className="w-[2px] h-[2px] bg-[color:var(--color-gray-500,#808080)] rounded-full" />
+            <span className="text-[color:var(--color-gray-500,#808080)] text-[12px] leading-[1.33] tracking-[-0.3px]">
+              {date}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <StatItem icon="heart" count={stats.likes} />
+            <StatItem icon="comment" count={stats.comments} />
+            <StatItem icon="view" count={stats.views} />
+          </div>
+        </div>
+      </>
+    );
+
+    if (href) {
+      return (
+        <Link ref={ref as React.Ref<HTMLAnchorElement>} href={href} className={wrapperClasses}>
+          {content}
+        </Link>
+      );
+    }
 
     return (
       <div
         ref={ref}
-        className={`${baseClasses} ${stateClasses} ${cursorClass} ${className}`}
+        className={wrapperClasses}
         onClick={onClick}
         role={onClick ? "button" : undefined}
         tabIndex={onClick ? 0 : undefined}
-        onKeyDown={handleKeyDown}
       >
-        {/* 썸네일 */}
-        {thumbnail && (
-          <div className="w-full aspect-video mb-4 rounded-lg overflow-hidden">
-            <img src={thumbnail} alt={title} className="w-full h-full object-cover" />
-          </div>
-        )}
-
-        {/* 카테고리 뱃지 */}
-        {category && (
-          <div className="mb-4">
-            <span
-              className="inline-flex items-center h-6 px-3 rounded-full text-xs font-medium border"
-              style={{
-                backgroundColor: "#FFFFFF",
-                color: category.color || "var(--color-primary-800)",
-                borderColor: category.color || "var(--color-primary-800)",
-              }}
-            >
-              {category.label}
-            </span>
-          </div>
-        )}
-
-        {/* 제목 */}
-        <h3 className="mb-3 text-xl font-semibold leading-7 text-[var(--color-gray-800)] line-clamp-1">
-          {title}
-        </h3>
-
-        {/* 설명 */}
-        <p className="mb-4 text-sm leading-5 text-[var(--color-gray-600)] line-clamp-3">
-          {description}
-        </p>
-
-        {/* 작성자 정보 */}
-        <div className="flex items-center gap-2 mb-4">
-          <span className="text-xs text-[var(--color-gray-500)]">{author.name}</span>
-          <span className="text-xs text-[var(--color-gray-400)]">·</span>
-          <span className="text-xs text-[var(--color-gray-500)]">{date}</span>
-        </div>
-
-        {/* 통계 */}
-        <div className="flex items-center gap-4">
-          <StatItem icon="heart" count={stats.likes} />
-          <StatItem icon="comment" count={stats.comments} />
-          <StatItem icon="view" count={stats.views} />
-        </div>
+        {content}
       </div>
     );
   },

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -393,29 +393,36 @@ const StatItem: React.FC<{ icon: "heart" | "comment" | "view"; count: number }> 
 }) => {
   const icons = {
     heart: (
-      <path d="M8 14L7.05 13.15C3.4 9.86 1 7.69 1 5.05C1 2.88 2.68 1.2 4.85 1.2C6.04 1.2 7.19 1.76 8 2.64C8.81 1.76 9.96 1.2 11.15 1.2C13.32 1.2 15 2.88 15 5.05C15 7.69 12.6 9.86 8.95 13.15L8 14Z" />
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
     ),
-    comment: (
-      <path d="M14 2H2C1.45 2 1 2.45 1 3V11C1 11.55 1.45 12 2 12H12L15 15V3C15 2.45 14.55 2 14 2Z" />
-    ),
+    comment: <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />,
     view: (
-      <path d="M8 3C4.5 3 1.73 5.61 1 9C1.73 12.39 4.5 15 8 15C11.5 15 14.27 12.39 15 9C14.27 5.61 11.5 3 8 3ZM8 13C6.34 13 5 11.66 5 10C5 8.34 6.34 7 8 7C9.66 7 11 8.34 11 10C11 11.66 9.66 13 8 13ZM8 8.5C7.17 8.5 6.5 9.17 6.5 10C6.5 10.83 7.17 11.5 8 11.5C8.83 11.5 9.5 10.83 9.5 10C9.5 9.17 8.83 8.5 8 8.5Z" />
+      <>
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+        <circle cx="12" cy="12" r="3" />
+      </>
     ),
   };
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex items-center gap-1">
       <svg
         width="16"
         height="16"
-        viewBox="0 0 16 16"
-        fill="currentColor"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         xmlns="http://www.w3.org/2000/svg"
-        className="text-[var(--color-gray-500)]"
+        className="text-[color:var(--color-gray-500,#808080)]"
       >
         {icons[icon]}
       </svg>
-      <span className="text-xs font-medium text-[var(--color-gray-500)]">{count}</span>
+      <span className="text-[12px] font-medium leading-[1.33] tracking-[-0.3px] text-[color:var(--color-gray-500,#808080)]">
+        {count}
+      </span>
     </div>
   );
 };


### PR DESCRIPTION
[Fix] #92  - PostCard 컴포넌트 피그마 기준 QA 반영

  ## 🔎 What is this PR?

  - design-guide PortfolioCard 기준으로 PostCard 컴포넌트 디자인 불일치 수정

  ---

  ## 📝 Changes

  - `category` 단일 뱃지 → `tags: string[]` 복수 태그 구조로 변경
  - 썸네일 `aspect-[360/203]` + 상하 분리 border 구조 + hover scale 효과 적용
  - `href` prop 추가로 `next/link` Link 래핑 지원
  - 제목 `tracking-[-0.5px]`, 설명 `line-clamp-1` + `tracking-[-0.35px]` 적용
  - author/date 구분자 텍스트 `·` → 2px dot 요소로 교체
  - StatItem 아이콘 fill 기반 → Lucide 스타일 stroke SVG(`viewBox="0 0 24 24"`)로 교체

  ---

  ## ✔ Checklist

  - [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
  - [x] ESLint / Prettier 통과 (`pnpm lint`)
  - [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
  - [x] 관련 문서/주석 반영 (필요 시)
  - [x] 주요 로직에 테스트 또는 검증 완료

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Post cards now support direct link navigation

* **Style**
  * Redesigned post card layout with improved spacing and typography
  * Replaced category badges with flexible multi-value tag chips for better content categorization
  * Updated stat item icons and styling for improved visual consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->