### PR TITLE
[Fix] #97 - 공유 UI 디자인 QA 통합 반영

### DIFF
--- a/src/shared/ui/card/card.stories.tsx
+++ b/src/shared/ui/card/card.stories.tsx
@@ -34,10 +34,7 @@ export const PostCard: Story = {
   args: {
     variant: "post",
     thumbnail: storyDefaultImage,
-    category: {
-      label: "기술",
-      color: "#4F46E5",
-    },
+    tags: ["React", "Next.js", "TypeScript"],
     title: "React Server Components 이해하기",
     description:
       "새로운 React Server Components에 대한 깊이 있는 탐구와 애플리케이션 성능 향상 방법을 알아봅니다.",

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import Link from "next/link";
 import { Button } from "../button";
 
 export type CardVariant = "post" | "profile" | "simple" | "featured";
@@ -8,11 +9,6 @@ export type SimpleCardVariant = "default" | "bordered" | "elevated";
 interface BaseCardProps {
   className?: string;
   onClick?: () => void;
-}
-
-interface CategoryBadge {
-  label: string;
-  color?: string;
 }
 
 interface Author {
@@ -34,14 +30,14 @@ interface ProfileStats {
 // 개별 카드 타입 정의
 interface PostCardSpecificProps {
   variant: "post";
-  thumbnail?: string;
-  category?: CategoryBadge;
+  href?: string;
+  thumbnail?: string | { src: string };
+  tags?: string[];
   title: string;
   description: string;
   author: Author;
   date: string;
   stats: PostStats;
-  isSelected?: boolean;
 }
 
 interface ProfileCardSpecificProps {
@@ -101,26 +97,21 @@ Card.displayName = "Card";
 const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { variant: "post" }>>(
   (props, ref) => {
     const {
+      href,
       thumbnail,
-      category,
+      tags,
       title,
       description,
       author,
       date,
       stats,
-      isSelected = false,
       className = "",
       onClick,
     } = props;
 
-    const baseClasses =
-      "w-full min-w-[280px] max-w-[360px] p-6 bg-white border rounded-xl transition-all duration-200 ease-out";
-
-    const stateClasses = isSelected
-      ? "bg-[var(--color-primary-50)] border-[var(--color-primary-800)] shadow-[0_4px_12px_rgba(0,74,156,0.12)]"
-      : "border-[var(--color-gray-200)] shadow-[0_2px_8px_rgba(0,0,0,0.04)] hover:border-[var(--color-primary-200)] hover:shadow-[0_4px_16px_rgba(0,0,0,0.08)] hover:-translate-y-0.5";
-
-    const cursorClass = onClick ? "cursor-pointer" : "";
+    const wrapperClasses = `flex w-full min-w-[280px] max-w-[360px] flex-col group ${
+      href || onClick ? "cursor-pointer" : ""
+    } ${className}`;
 
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (!onClick) return;
@@ -130,61 +121,82 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
       }
     };
 
+    const content = (
+      <>
+        {thumbnail && (
+          <div className="relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden">
+            <img
+              src={typeof thumbnail === "string" ? thumbnail : thumbnail.src}
+              alt={title}
+              className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+            />
+          </div>
+        )}
+
+        <div className="bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 rounded-b-xl">
+          {tags && tags.length > 0 && (
+            <div className="flex gap-2 flex-wrap">
+              {tags.map((tag, index) => (
+                <span
+                  key={index}
+                  className="border border-[color:var(--color-primary-800,#003876)] text-[color:var(--color-primary-800,#003876)] text-[12px] font-medium leading-[1.33] tracking-[-0.3px] px-3 py-1 rounded-xl"
+                >
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <h3 className="text-[color:var(--color-gray-800,#333)] text-[20px] font-semibold leading-[1.4] tracking-[-0.5px] line-clamp-1">
+            {title}
+          </h3>
+
+          <p className="text-[color:var(--color-gray-600,#666)] text-[14px] leading-[1.43] tracking-[-0.35px] line-clamp-1">
+            {description}
+          </p>
+
+          <div className="flex items-center gap-1">
+            <span className="text-[color:var(--color-gray-500,#808080)] text-[12px] leading-[1.33] tracking-[-0.3px]">
+              {author.name}
+            </span>
+            <div className="w-[2px] h-[2px] bg-[color:var(--color-gray-500,#808080)] rounded-full" />
+            <span className="text-[color:var(--color-gray-500,#808080)] text-[12px] leading-[1.33] tracking-[-0.3px]">
+              {date}
+            </span>
+          </div>
+
+          <div className="flex items-center gap-4">
+            <StatItem icon="heart" count={stats.likes} />
+            <StatItem icon="comment" count={stats.comments} />
+            <StatItem icon="view" count={stats.views} />
+          </div>
+        </div>
+      </>
+    );
+
+    if (href) {
+      return (
+        <Link
+          ref={ref as React.Ref<HTMLAnchorElement>}
+          href={href}
+          className={wrapperClasses}
+          onClick={onClick}
+        >
+          {content}
+        </Link>
+      );
+    }
+
     return (
       <div
         ref={ref}
-        className={`${baseClasses} ${stateClasses} ${cursorClass} ${className}`}
+        className={wrapperClasses}
         onClick={onClick}
         role={onClick ? "button" : undefined}
         tabIndex={onClick ? 0 : undefined}
         onKeyDown={handleKeyDown}
       >
-        {/* 썸네일 */}
-        {thumbnail && (
-          <div className="w-full aspect-video mb-4 rounded-lg overflow-hidden">
-            <img src={thumbnail} alt={title} className="w-full h-full object-cover" />
-          </div>
-        )}
-
-        {/* 카테고리 뱃지 */}
-        {category && (
-          <div className="mb-4">
-            <span
-              className="inline-flex items-center h-6 px-3 rounded-full text-xs font-medium border"
-              style={{
-                backgroundColor: "#FFFFFF",
-                color: category.color || "var(--color-primary-800)",
-                borderColor: category.color || "var(--color-primary-800)",
-              }}
-            >
-              {category.label}
-            </span>
-          </div>
-        )}
-
-        {/* 제목 */}
-        <h3 className="mb-3 text-xl font-semibold leading-7 text-[var(--color-gray-800)] line-clamp-1">
-          {title}
-        </h3>
-
-        {/* 설명 */}
-        <p className="mb-4 text-sm leading-5 text-[var(--color-gray-600)] line-clamp-3">
-          {description}
-        </p>
-
-        {/* 작성자 정보 */}
-        <div className="flex items-center gap-2 mb-4">
-          <span className="text-xs text-[var(--color-gray-500)]">{author.name}</span>
-          <span className="text-xs text-[var(--color-gray-400)]">·</span>
-          <span className="text-xs text-[var(--color-gray-500)]">{date}</span>
-        </div>
-
-        {/* 통계 */}
-        <div className="flex items-center gap-4">
-          <StatItem icon="heart" count={stats.likes} />
-          <StatItem icon="comment" count={stats.comments} />
-          <StatItem icon="view" count={stats.views} />
-        </div>
+        {content}
       </div>
     );
   },
@@ -397,29 +409,36 @@ const StatItem: React.FC<{ icon: "heart" | "comment" | "view"; count: number }> 
 }) => {
   const icons = {
     heart: (
-      <path d="M8 14L7.05 13.15C3.4 9.86 1 7.69 1 5.05C1 2.88 2.68 1.2 4.85 1.2C6.04 1.2 7.19 1.76 8 2.64C8.81 1.76 9.96 1.2 11.15 1.2C13.32 1.2 15 2.88 15 5.05C15 7.69 12.6 9.86 8.95 13.15L8 14Z" />
+      <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
     ),
-    comment: (
-      <path d="M14 2H2C1.45 2 1 2.45 1 3V11C1 11.55 1.45 12 2 12H12L15 15V3C15 2.45 14.55 2 14 2Z" />
-    ),
+    comment: <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />,
     view: (
-      <path d="M8 3C4.5 3 1.73 5.61 1 9C1.73 12.39 4.5 15 8 15C11.5 15 14.27 12.39 15 9C14.27 5.61 11.5 3 8 3ZM8 13C6.34 13 5 11.66 5 10C5 8.34 6.34 7 8 7C9.66 7 11 8.34 11 10C11 11.66 9.66 13 8 13ZM8 8.5C7.17 8.5 6.5 9.17 6.5 10C6.5 10.83 7.17 11.5 8 11.5C8.83 11.5 9.5 10.83 9.5 10C9.5 9.17 8.83 8.5 8 8.5Z" />
+      <>
+        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+        <circle cx="12" cy="12" r="3" />
+      </>
     ),
   };
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div className="flex items-center gap-1">
       <svg
         width="16"
         height="16"
-        viewBox="0 0 16 16"
-        fill="currentColor"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
         xmlns="http://www.w3.org/2000/svg"
-        className="text-[var(--color-gray-500)]"
+        className="text-[color:var(--color-gray-500,#808080)]"
       >
         {icons[icon]}
       </svg>
-      <span className="text-xs font-medium text-[var(--color-gray-500)]">{count}</span>
+      <span className="text-[12px] font-medium leading-[1.33] tracking-[-0.3px] text-[color:var(--color-gray-500,#808080)]">
+        {count}
+      </span>
     </div>
   );
 };

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -535,7 +535,7 @@ export const UploadIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
 );
 
 // Inbox 아이콘
-export const InboxIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
+export const InboxIcon: React.FC<IconProps> = ({ size = 20, strokeWidth = 2, ...props }) => (
   <svg
     width={size}
     height={size}
@@ -547,13 +547,13 @@ export const InboxIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
     <path
       d="M3.33333 4.16667H16.6667L15 15.8333H5L3.33333 4.16667Z"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth={strokeWidth}
       strokeLinejoin="round"
     />
     <path
       d="M3.33333 11.6667H7.5L8.75 13.3333H11.25L12.5 11.6667H16.6667"
       stroke="currentColor"
-      strokeWidth="2"
+      strokeWidth={strokeWidth}
       strokeLinecap="round"
       strokeLinejoin="round"
     />

--- a/src/shared/ui/lists/lists.tsx
+++ b/src/shared/ui/lists/lists.tsx
@@ -62,27 +62,25 @@ const listItemBaseClasses =
   "flex flex-row items-center w-full min-h-[64px] px-[20px] py-[16px] gap-[16px] border-b border-[color:var(--color-gray-200,#E5E5E5)] transition-colors duration-200 outline-none";
 
 // --- Table 스타일 ---
-const tableContainerClasses =
-  "w-full flex flex-col border border-[color:var(--color-gray-200,#E5E5E5)] rounded-[8px] overflow-hidden bg-white";
-const tableHeaderRowClasses =
-  "flex flex-row items-center w-full h-[48px] px-[20px] py-[12px] bg-[color:var(--color-gray-50,#F9F9F9)] border-b-[2px] border-[color:var(--color-gray-300,#CCCCCC)]";
-const tableRowBaseClasses =
-  "flex flex-row items-center w-full min-h-[56px] px-[20px] py-[16px] border-b border-[color:var(--color-gray-200,#E5E5E5)] transition-colors duration-200";
+const tableThBaseClasses =
+  "bg-[color:var(--color-gray-100,#f2f2f2)] border-b border-t-2 border-[color:var(--color-gray-200,#e5e5e5)] h-12 px-5 py-3 text-[color:var(--color-gray-800,#333)] text-[16px] font-semibold leading-[1.5] tracking-[-0.4px]";
+const tableTdBaseClasses =
+  "border border-[color:var(--color-gray-200,#e5e5e5)] border-t-0 border-l-0 h-[56px] px-5 py-4 text-[color:var(--color-gray-800,#333)] text-[14px] leading-[1.43] tracking-[-0.35px]";
 
 // 너비 맵핑 클래스
 const columnWidthClasses: Record<TableColumnWidth, string> = {
-  checkbox: "w-[48px] flex-shrink-0",
-  sm: "w-[80px] flex-shrink-0",
-  md: "w-[120px] flex-shrink-0",
-  lg: "w-[200px] flex-shrink-0",
-  fill: "flex-1 min-w-0",
+  checkbox: "w-[48px]",
+  sm: "w-[80px]",
+  md: "w-[120px]",
+  lg: "w-[200px]",
+  fill: "",
 };
 
 // 정렬 맵핑 클래스
 const columnAlignClasses: Record<TableColumnAlign, string> = {
-  left: "justify-start text-left",
-  center: "justify-center text-center",
-  right: "justify-end text-right",
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
 };
 
 // ----------------------------------------------------------------------
@@ -102,15 +100,10 @@ const getListItemClasses = (isActive: boolean, isDisabled: boolean): string => {
 };
 
 const getTableRowClasses = (isSelected: boolean, isDisabled: boolean): string => {
-  if (isDisabled) {
-    return [tableRowBaseClasses, "bg-white opacity-50 cursor-not-allowed"].join(" ");
-  }
-
-  const stateClasses = isSelected
-    ? "bg-[color:var(--color-primary-50,#F0F6FD)] border-[color:var(--color-primary-200,#B3D1F7)]"
-    : "bg-white hover:bg-[color:var(--color-gray-50,#F9F9F9)] cursor-pointer";
-
-  return [tableRowBaseClasses, stateClasses].join(" ");
+  if (isDisabled) return "opacity-50 cursor-not-allowed";
+  if (isSelected)
+    return "bg-[color:var(--color-primary-50,#F0F6FD)] cursor-pointer transition-colors";
+  return "hover:bg-[color:var(--color-gray-50,#F9F9F9)] cursor-pointer transition-colors";
 };
 
 // ----------------------------------------------------------------------
@@ -240,103 +233,99 @@ export const Table = ({
   onRowCheck,
   onCheckAll,
 }: TableProps): React.ReactElement => {
-  return (
-    <div className={tableContainerClasses}>
-      {/* Table Header */}
-      <div className={tableHeaderRowClasses}>
-        {hasCheckbox && (
-          <div className={`${columnWidthClasses.checkbox} flex items-center justify-center`}>
-            <input
-              type="checkbox"
-              checked={isAllChecked}
-              onChange={(e) => onCheckAll && onCheckAll(e.target.checked)}
-              className="w-4 h-4 cursor-pointer accent-[color:var(--color-primary-800,#004A9C)]"
-            />
-          </div>
-        )}
-        {columns.map((col) => (
-          <div
-            key={col.id}
-            className={`flex items-center ${columnWidthClasses[col.width || "fill"]} ${
-              columnAlignClasses[col.align || "left"]
-            }`}
-          >
-            <span className="text-[14px] font-semibold leading-[20px] text-[color:var(--color-gray-800,#333333)] truncate">
-              {col.label}
-            </span>
-          </div>
-        ))}
-      </div>
+  const totalCols = columns.length + (hasCheckbox ? 1 : 0);
 
-      {/* Table Body (Empty State) */}
-      {isEmpty || data.length === 0 ? (
-        <div className="flex flex-col items-center justify-center w-full h-[200px] gap-2 bg-white">
-          <InboxIcon size={48} className="text-[color:var(--color-gray-400,#999999)]" />
-          <span className="text-[14px] text-[color:var(--color-gray-500,#808080)]">
-            데이터가 없습니다
-          </span>
-        </div>
-      ) : (
-        /* Table Body (Rows) */
-        <div className="flex flex-col w-full">
-          {data.map((row) => {
+  return (
+    <table className="w-full border-collapse">
+      <thead>
+        <tr>
+          {hasCheckbox && (
+            <th className={`${tableThBaseClasses} w-[48px] text-center`}>
+              <input
+                type="checkbox"
+                checked={isAllChecked}
+                onChange={(e) => onCheckAll && onCheckAll(e.target.checked)}
+                className="w-4 h-4 cursor-pointer accent-[color:var(--color-primary-800,#004A9C)]"
+              />
+            </th>
+          )}
+          {columns.map((col, i) => (
+            <th
+              key={col.id}
+              className={[
+                tableThBaseClasses,
+                i > 0 || hasCheckbox ? "border-l" : "",
+                columnWidthClasses[col.width || "fill"],
+                columnAlignClasses[col.align || "center"],
+              ].join(" ")}
+            >
+              {col.label}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {isEmpty || data.length === 0 ? (
+          <tr>
+            <td colSpan={totalCols}>
+              <div className="flex flex-col items-center justify-center w-full h-[200px] gap-2">
+                <InboxIcon
+                  size={48}
+                  strokeWidth={1}
+                  className="text-[color:var(--color-gray-400,#999999)]"
+                />
+                <span className="text-[14px] text-[color:var(--color-gray-500,#808080)]">
+                  데이터가 없습니다
+                </span>
+              </div>
+            </td>
+          </tr>
+        ) : (
+          data.map((row) => {
             const isSelected = !!row.isSelected;
             const isDisabled = !!row.isDisabled;
 
-            const handleRowClick = () => {
-              if (!isDisabled && onRowClick) onRowClick(row.id);
-            };
-
-            const handleCheckClick = (e: React.MouseEvent) => {
-              e.stopPropagation();
-              if (!isDisabled && onRowCheck) onRowCheck(row.id, !isSelected);
-            };
-
             return (
-              <div
+              <tr
                 key={row.id}
                 className={getTableRowClasses(isSelected, isDisabled)}
-                onClick={handleRowClick}
+                onClick={() => !isDisabled && onRowClick && onRowClick(row.id)}
               >
                 {hasCheckbox && (
-                  <div
-                    className={`${columnWidthClasses.checkbox} flex items-center justify-center`}
-                    onClick={handleCheckClick}
+                  <td
+                    className={`${tableTdBaseClasses} text-center`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      if (!isDisabled && onRowCheck) onRowCheck(row.id, !isSelected);
+                    }}
                   >
                     <input
                       type="checkbox"
                       checked={isSelected}
                       disabled={isDisabled}
-                      onChange={() => {
-                        if (onRowCheck) {
-                          onRowCheck(row.id, !isSelected);
-                        }
-                      }}
-                      onClick={(e) => {
-                        // 부모 영역의 클릭 이벤트와 중복(버블링)되어 두 번 토글되는 현상 방지
-                        e.stopPropagation();
-                      }}
+                      onChange={() => onRowCheck && onRowCheck(row.id, !isSelected)}
+                      onClick={(e) => e.stopPropagation()}
                       className="w-4 h-4 cursor-pointer accent-[color:var(--color-primary-800,#004A9C)]"
                     />
-                  </div>
+                  </td>
                 )}
-                {columns.map((col) => (
-                  <div
+                {columns.map((col, i) => (
+                  <td
                     key={col.id}
-                    className={`flex items-center ${columnWidthClasses[col.width || "fill"]} ${
-                      columnAlignClasses[col.align || "left"]
-                    }`}
+                    className={[
+                      tableTdBaseClasses,
+                      i === columns.length - 1 ? "border-r-0" : "",
+                      columnAlignClasses[col.align || "center"],
+                    ].join(" ")}
                   >
-                    <span className="text-[14px] leading-[20px] text-[color:var(--color-gray-600,#666666)] truncate w-full">
-                      {row[col.id]}
-                    </span>
-                  </div>
+                    {row[col.id]}
+                  </td>
                 ))}
-              </div>
+              </tr>
             );
-          })}
-        </div>
-      )}
-    </div>
+          })
+        )}
+      </tbody>
+    </table>
   );
 };


### PR DESCRIPTION
## 🔎 What is this PR?

- 파일 구조 정리 이전에 분리되어 올라온 PostCard/Table QA PR을 현재 구조 기준으로 통합 반영합니다.

---

## 📝 Changes

- PostCard를 디자인 가이드 기준 layout, tag, link, typography, stat icon 구조로 정리
- Table을 flex 레이아웃에서 semantic HTML table 구조로 정리
- `InboxIcon`의 `strokeWidth` prop 반영
- 관련 Storybook args와 QA 케이스 갱신

---

## 📸 Screenshots

- PostCard Storybook 확인
- Table Storybook 확인

---

## 📚 Background / Context

- 기존 PR #94, #95는 구조 정리 이전 기준이라 #97에서 단일 작업으로 재반영했습니다.
- 현재 구조에서는 공유 UI 변경만 `src/shared/ui` 안에 유지하고, `src/app`, `src/screens`, `src/api`, `src/lib`는 변경하지 않았습니다.

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] Storybook 빌드 통과 (`pnpm exec storybook build --quiet`)
- [x] Storybook에서 PostCard/Table 주요 상태 확인
- [x] 기존 PR #94, #95 내용이 통합됨

---

## 🙏 Request

- PostCard와 Table이 디자인 가이드 기준으로 맞는지 확인 부탁드립니다.

Closes #97
