### PR TITLE
[Fix] #99 - PostCard QA 후속 반영

### DIFF
--- a/src/shared/ui/card/card.stories.tsx
+++ b/src/shared/ui/card/card.stories.tsx
@@ -50,6 +50,13 @@ export const PostCard: Story = {
   },
 };
 
+export const PostCardWithHref: Story = {
+  args: {
+    ...PostCard.args,
+    href: "/home",
+  },
+};
+
 export const ProfileCard: Story = {
   args: {
     variant: "profile",

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -176,12 +176,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
 
     if (href) {
       return (
-        <Link
-          ref={ref as React.Ref<HTMLAnchorElement>}
-          href={href}
-          className={wrapperClasses}
-          onClick={onClick}
-        >
+        <Link href={href} className={wrapperClasses} onClick={onClick}>
           {content}
         </Link>
       );


### PR DESCRIPTION
## 🔎 What is this PR?

- PR #98 merge 이후 남은 PostCard QA 후속 항목을 별도 PR로 반영합니다.

---

## 📝 Changes

- `href`가 있는 PostCard에서 `HTMLDivElement` ref를 `Link`에 전달하지 않도록 수정
- `href` 분기를 확인할 수 있는 PostCard Storybook 케이스 추가

---

## 📚 Background / Context

- PR #98은 이미 merge되어 #97이 닫힌 상태라, 후속 작업을 #99로 분리했습니다.
- 접근성 전반 리뷰는 이번 범위에서 제외하고, 타입 계약과 Storybook QA 커버리지만 반영했습니다.

---

## ✔ Checklist

- [x] ESLint 통과 (`pnpm lint`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] 앱 빌드 통과 (`pnpm build`)
- [x] Storybook 빌드 통과 (`pnpm exec storybook build --quiet`)

Closes #99
