### PR TITLE
[Feat] #102 - 인증 토큰 자동 주입 API 클라이언트 추가

### DIFF
--- a/src/api/README.md
+++ b/src/api/README.md
@@ -1,0 +1,51 @@
+# API client
+
+백엔드 API 호출은 `backendFetch` 또는 `backendJson`을 사용합니다.
+
+```ts
+import { backendJson } from "@/api/client";
+
+type Portfolio = {
+  id: number;
+  title: string;
+};
+
+const portfolios = await backendJson<Portfolio[]>("/api/portfolios");
+```
+
+기본값은 인증이 필요한 요청입니다. Firebase 로그인 사용자가 있으면
+`auth.currentUser.getIdToken()`으로 Firebase ID Token을 가져와
+`Authorization: Bearer {token}` 헤더를 자동으로 추가합니다.
+
+공개 API처럼 인증이 필요 없는 요청은 `requiresAuth: false`를 사용합니다.
+
+```ts
+const notices = await backendJson<Notice[]>("/api/notices", {
+  requiresAuth: false,
+});
+```
+
+JSON 요청은 `json` 옵션을 사용합니다.
+
+```ts
+await backendJson<UserProfile, UpdateUserProfileRequest>("/api/users/me", {
+  method: "PATCH",
+  json: {
+    name: "권세빈",
+    department: "소프트웨어및컴퓨터공학전공",
+  },
+});
+```
+
+파일 업로드처럼 `FormData`를 보내는 경우에는 `body`를 사용합니다. 이때
+`Content-Type`은 브라우저가 boundary를 포함해 설정해야 하므로 직접 지정하지 않습니다.
+
+```ts
+const formData = new FormData();
+formData.append("file", file);
+
+await backendJson<UploadResponse>("/api/files", {
+  method: "POST",
+  body: formData,
+});
+```

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,159 @@
+"use client";
+
+import { auth } from "@/shared/config/firebase";
+
+export type BackendFetchOptions = RequestInit & {
+  requiresAuth?: boolean;
+};
+
+export type BackendJsonOptions<RequestBody = unknown> = Omit<BackendFetchOptions, "body"> & {
+  body?: BodyInit | null;
+  json?: RequestBody;
+};
+
+type BackendApiErrorOptions = {
+  status?: number;
+  payload?: unknown;
+  response?: Response;
+};
+
+export class BackendApiError extends Error {
+  status?: number;
+  payload?: unknown;
+  response?: Response;
+
+  constructor(message: string, options: BackendApiErrorOptions = {}) {
+    super(message);
+    this.name = "BackendApiError";
+    this.status = options.status;
+    this.payload = options.payload;
+    this.response = options.response;
+  }
+}
+
+const getBackendApiBaseUrl = (): string => {
+  const backendApiBaseUrl = process.env.NEXT_PUBLIC_BACKEND_API_BASE_URL ?? "";
+
+  return backendApiBaseUrl.replace(/\/$/, "");
+};
+
+const createBackendApiUrl = (path: string): string => {
+  if (/^https?:\/\//.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  return `${getBackendApiBaseUrl()}${normalizedPath}`;
+};
+
+const isFormDataBody = (body: BodyInit | null | undefined): body is FormData =>
+  typeof FormData !== "undefined" && body instanceof FormData;
+
+const parseResponsePayload = async (response: Response): Promise<unknown> => {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    return response.json().catch(() => undefined);
+  }
+
+  return response.text().catch(() => undefined);
+};
+
+const getErrorMessage = (payload: unknown, status: number): string => {
+  if (payload && typeof payload === "object" && "message" in payload) {
+    const message = (payload as { message?: unknown }).message;
+
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+
+  if (typeof payload === "string" && payload.trim()) {
+    return payload;
+  }
+
+  return `Backend API request failed. (${status})`;
+};
+
+const throwBackendApiError = async (response: Response): Promise<never> => {
+  const payload = await parseResponsePayload(response);
+
+  throw new BackendApiError(getErrorMessage(payload, response.status), {
+    status: response.status,
+    payload,
+    response,
+  });
+};
+
+const appendAuthHeader = async (headers: Headers): Promise<void> => {
+  if (headers.has("Authorization")) {
+    return;
+  }
+
+  const currentUser = auth.currentUser;
+
+  if (!currentUser) {
+    throw new BackendApiError("로그인이 필요한 요청입니다.", { status: 401 });
+  }
+
+  const idToken = await currentUser.getIdToken();
+  headers.set("Authorization", `Bearer ${idToken}`);
+};
+
+export const backendFetch = async (
+  path: string,
+  { requiresAuth = true, headers: headersInit, ...init }: BackendFetchOptions = {},
+): Promise<Response> => {
+  const headers = new Headers(headersInit);
+
+  if (requiresAuth) {
+    await appendAuthHeader(headers);
+  }
+
+  const response = await fetch(createBackendApiUrl(path), {
+    ...init,
+    headers,
+  });
+
+  if (!response.ok) {
+    await throwBackendApiError(response);
+  }
+
+  return response;
+};
+
+export const backendJson = async <ResponseBody, RequestBody = unknown>(
+  path: string,
+  { json, body, headers: headersInit, method, ...init }: BackendJsonOptions<RequestBody> = {},
+): Promise<ResponseBody> => {
+  if (json !== undefined && body !== undefined) {
+    throw new BackendApiError("body와 json은 동시에 사용할 수 없습니다.");
+  }
+
+  const requestBody = json === undefined ? body : JSON.stringify(json);
+  const headers = new Headers(headersInit);
+
+  if (json !== undefined && !headers.has("Content-Type") && !isFormDataBody(requestBody)) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const response = await backendFetch(path, {
+    ...init,
+    method: method ?? (json === undefined ? undefined : "POST"),
+    headers,
+    body: requestBody,
+  });
+
+  if (response.status === 204) {
+    return undefined as ResponseBody;
+  }
+
+  const responseText = await response.text();
+
+  if (!responseText) {
+    return undefined as ResponseBody;
+  }
+
+  return JSON.parse(responseText) as ResponseBody;
+};


### PR DESCRIPTION
## 🔎 What is this PR?

- Firebase 로그인 이후 백엔드 API 호출 시 Firebase ID Token을 자동으로 주입하는 공통 API 클라이언트를 추가합니다.

---

## 📝 Changes

- `backendFetch` 추가
- `backendJson` 추가
- `BackendApiError` 추가
- 인증 불필요 요청을 위한 `requiresAuth: false` 옵션 추가
- JSON 요청과 `FormData` 요청 사용 예시 문서화

---

## 📚 Background / Context

- 기존에는 `/api/auth/login` 요청에서만 직접 `Authorization: Bearer {idToken}` 헤더를 붙였습니다.
- 신규 API 연동 시 팀원들이 매번 Firebase 토큰을 직접 가져오지 않도록 `fetch` 기반 래퍼를 추가했습니다.
- 토큰은 별도 저장하지 않고 Firebase Auth의 `auth.currentUser.getIdToken()`에서 가져옵니다.

---

## ✔ Checklist

- [x] ESLint 통과 (`pnpm lint`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] 앱 빌드 통과 (`pnpm build`)

Closes #102
