### PR TITLE
[Feat] #108 - 기업 회원가입 플로우 구현

### DIFF
--- a/src/lib/auth/auth-error-message.ts
+++ b/src/lib/auth/auth-error-message.ts
@@ -7,6 +7,10 @@ export const getAuthErrorMessage = (error: unknown): string => {
     switch (code) {
       case "auth/invalid-email":
         return "이메일 형식이 올바르지 않습니다.";
+      case "auth/email-already-in-use":
+        return "이미 가입된 이메일입니다.";
+      case "auth/weak-password":
+        return "비밀번호는 6자 이상으로 입력해주세요.";
       case "auth/user-not-found":
       case "auth/wrong-password":
       case "auth/invalid-credential":

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -1,10 +1,12 @@
 "use client";
 
 import {
+  createUserWithEmailAndPassword,
   GoogleAuthProvider,
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut as firebaseSignOut,
+  updateProfile,
 } from "firebase/auth";
 import {
   fetchGoogleProfile,
@@ -19,6 +21,11 @@ type SessionResponse = {
   uid: string;
   email: string | null;
   backendUser: BackendUser;
+};
+
+type CompanySignupProfile = {
+  companyName: string;
+  name: string;
 };
 
 const googleProvider = new GoogleAuthProvider();
@@ -78,6 +85,26 @@ export const signInWithEmail = async (
     role: "COMPANY",
     name: credential.user.displayName ?? credential.user.email ?? email,
     department: "",
+  });
+};
+
+export const signUpCompanyWithEmail = async (
+  email: string,
+  password: string,
+  profile: CompanySignupProfile,
+): Promise<SessionResponse> => {
+  const credential = await createUserWithEmailAndPassword(auth, email, password);
+
+  await updateProfile(credential.user, {
+    displayName: profile.name,
+  });
+
+  const idToken = await credential.user.getIdToken();
+
+  return createSession(idToken, {
+    role: "COMPANY",
+    name: profile.name,
+    department: profile.companyName,
   });
 };
 

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,3 +1,3 @@
-export { signInWithEmail, signInWithGoogle, signOut } from "./auth-service";
+export { signInWithEmail, signInWithGoogle, signOut, signUpCompanyWithEmail } from "./auth-service";
 export { getAuthErrorMessage } from "./auth-error-message";
 export type { AuthRole, BackendLoginRequest, BackendUser } from "@/api/auth";

--- a/src/screens/login/company-login-form.tsx
+++ b/src/screens/login/company-login-form.tsx
@@ -1,74 +1,212 @@
 import { Button } from "@/shared/ui/button/button";
 import { Input } from "@/shared/ui/input";
-import { LockIcon, MailIcon } from "@/shared/ui/icons";
+import { AtSignIcon, BuildingIcon, LockIcon, MailIcon, UserIcon } from "@/shared/ui/icons";
 
-type CompanyLoginFormProps = {
+export type CompanyAuthMode = "login" | "signup";
+
+export type CompanySignupValues = {
+  companyName: string;
+  name: string;
+  username: string;
   email: string;
   password: string;
+  passwordConfirm: string;
+};
+
+type CompanyLoginFormProps = {
+  mode: CompanyAuthMode;
+  email: string;
+  password: string;
+  signupValues: CompanySignupValues;
   isSubmitting: boolean;
   onEmailChange: (email: string) => void;
   onPasswordChange: (password: string) => void;
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onSignupValueChange: (name: keyof CompanySignupValues, value: string) => void;
+  onModeChange: (mode: CompanyAuthMode) => void;
+  onLoginSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onSignupSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
 };
 
+const inputClassName = "rounded-[4px] text-[14px] shadow-none";
+const signupInputClassName = "h-[44px] rounded-[4px] text-[14px] shadow-none md:h-12";
+const iconClassName = "!text-[#8c8c8c] hover:!text-[#8c8c8c]";
+
 export const CompanyLoginForm = ({
+  mode,
   email,
   password,
+  signupValues,
   isSubmitting,
   onEmailChange,
   onPasswordChange,
-  onSubmit,
-}: CompanyLoginFormProps): React.ReactElement => (
-  <form onSubmit={onSubmit} className="flex flex-col gap-2">
-    <label htmlFor="login-email" className="text-[16px] font-medium leading-5 text-[#000000]">
-      이메일
-    </label>
-    <Input
-      id="login-email"
-      type="email"
-      value={email}
-      onChange={(event) => onEmailChange(event.target.value)}
-      disabled={isSubmitting}
-      leftIcon={<MailIcon width={18} />}
-      iconClassName="!text-[#000000] hover:!text-[#000000]"
-      size="large"
-      isFullWidth
-      className="rounded-[4px] text-[14px] shadow-none"
-    />
+  onSignupValueChange,
+  onModeChange,
+  onLoginSubmit,
+  onSignupSubmit,
+}: CompanyLoginFormProps): React.ReactElement => {
+  if (mode === "signup") {
+    return (
+      <form onSubmit={onSignupSubmit} className="flex flex-col gap-4">
+        <Input
+          id="company-signup-company-name"
+          type="text"
+          value={signupValues.companyName}
+          onChange={(event) => onSignupValueChange("companyName", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="회사명"
+          aria-label="회사명"
+          leftIcon={<BuildingIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
+        <Input
+          id="company-signup-name"
+          type="text"
+          value={signupValues.name}
+          onChange={(event) => onSignupValueChange("name", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="이름"
+          aria-label="이름"
+          leftIcon={<UserIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
+        <Input
+          id="company-signup-username"
+          type="text"
+          value={signupValues.username}
+          onChange={(event) => onSignupValueChange("username", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="아이디"
+          aria-label="아이디"
+          leftIcon={<AtSignIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
+        <Input
+          id="company-signup-email"
+          type="email"
+          value={signupValues.email}
+          onChange={(event) => onSignupValueChange("email", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="이메일"
+          aria-label="이메일"
+          leftIcon={<MailIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
+        <Input
+          id="company-signup-password"
+          type="password"
+          value={signupValues.password}
+          onChange={(event) => onSignupValueChange("password", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="비밀번호"
+          aria-label="비밀번호"
+          leftIcon={<LockIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
+        <Input
+          id="company-signup-password-confirm"
+          type="password"
+          value={signupValues.passwordConfirm}
+          onChange={(event) => onSignupValueChange("passwordConfirm", event.target.value)}
+          disabled={isSubmitting}
+          placeholder="비밀번호 확인"
+          aria-label="비밀번호 확인"
+          leftIcon={<LockIcon width={20} />}
+          iconClassName={iconClassName}
+          size="large"
+          isFullWidth
+          className={signupInputClassName}
+        />
 
-    <label
-      htmlFor="login-password"
-      className="mt-3 text-[16px] font-medium leading-5 text-[#000000]"
-    >
-      비밀번호
-    </label>
-    <Input
-      id="login-password"
-      type="password"
-      value={password}
-      onChange={(event) => onPasswordChange(event.target.value)}
-      disabled={isSubmitting}
-      leftIcon={<LockIcon width={18} />}
-      iconClassName="!text-[#000000] hover:!text-[#000000]"
-      size="large"
-      isFullWidth
-      className="rounded-[4px] text-[14px] shadow-none"
-    />
+        <Button
+          type="submit"
+          fullWidth
+          size="large"
+          isLoading={isSubmitting}
+          className="mt-3 rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100"
+        >
+          회원가입
+        </Button>
+        <button
+          type="button"
+          disabled={isSubmitting}
+          onClick={() => onModeChange("login")}
+          className="mt-1 text-center text-[16px] font-medium leading-[150%] text-[var(--color-primary-700)] hover:text-[var(--color-primary-800)] disabled:cursor-not-allowed disabled:text-[var(--color-gray-400)]"
+        >
+          이미 계정이 있으신가요? 로그인
+        </button>
+      </form>
+    );
+  }
 
-    <Button
-      type="submit"
-      fullWidth
-      size="large"
-      isLoading={isSubmitting}
-      className="mt-5 rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100"
-    >
-      로그인
-    </Button>
-    <a
-      href="#signup"
-      className="mt-3 text-center text-[16px] font-medium leading-[150%] tracking-[-0.025em] text-[#000000] hover:text-[var(--color-primary-800)]"
-    >
-      기업 계정이 없으신가요? 회원가입으로 이동하세요.
-    </a>
-  </form>
-);
+  return (
+    <form onSubmit={onLoginSubmit} className="flex flex-col gap-2">
+      <label htmlFor="login-email" className="text-[16px] font-medium leading-5 text-[#000000]">
+        이메일
+      </label>
+      <Input
+        id="login-email"
+        type="email"
+        value={email}
+        onChange={(event) => onEmailChange(event.target.value)}
+        disabled={isSubmitting}
+        leftIcon={<MailIcon width={18} />}
+        iconClassName="!text-[#000000] hover:!text-[#000000]"
+        size="large"
+        isFullWidth
+        className={inputClassName}
+      />
+
+      <label
+        htmlFor="login-password"
+        className="mt-3 text-[16px] font-medium leading-5 text-[#000000]"
+      >
+        비밀번호
+      </label>
+      <Input
+        id="login-password"
+        type="password"
+        value={password}
+        onChange={(event) => onPasswordChange(event.target.value)}
+        disabled={isSubmitting}
+        leftIcon={<LockIcon width={18} />}
+        iconClassName="!text-[#000000] hover:!text-[#000000]"
+        size="large"
+        isFullWidth
+        className={inputClassName}
+      />
+
+      <Button
+        type="submit"
+        fullWidth
+        size="large"
+        isLoading={isSubmitting}
+        className="mt-5 rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100"
+      >
+        로그인
+      </Button>
+      <button
+        type="button"
+        disabled={isSubmitting}
+        onClick={() => onModeChange("signup")}
+        className="mt-3 text-center text-[16px] font-medium leading-[150%] tracking-[-0.025em] text-[#000000] hover:text-[var(--color-primary-800)] disabled:cursor-not-allowed disabled:text-[var(--color-gray-400)]"
+      >
+        기업 계정이 없으신가요? 회원가입으로 이동하세요.
+      </button>
+    </form>
+  );
+};

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -2,9 +2,19 @@
 
 import { useState } from "react";
 import { useRouter } from "next/navigation";
-import { getAuthErrorMessage, signInWithEmail, signInWithGoogle } from "@/lib/auth";
+import {
+  getAuthErrorMessage,
+  signInWithEmail,
+  signInWithGoogle,
+  signUpCompanyWithEmail,
+} from "@/lib/auth";
+import type { BackendUser } from "@/api/auth";
 import { Navigation, Tabs, type NavItem, type TabItem } from "@/shared/ui";
-import { CompanyLoginForm } from "./company-login-form";
+import {
+  CompanyLoginForm,
+  type CompanyAuthMode,
+  type CompanySignupValues,
+} from "./company-login-form";
 import { StudentLoginPanel } from "./student-login-panel";
 import styles from "./login.module.css";
 
@@ -19,18 +29,57 @@ const loginTabs: TabItem[] = [
   { id: "company", label: "기업" },
 ];
 
+const initialCompanySignupValues: CompanySignupValues = {
+  companyName: "",
+  name: "",
+  username: "",
+  email: "",
+  password: "",
+  passwordConfirm: "",
+};
+
+const getCompanySignupStatusMessage = (status: BackendUser["status"]): string => {
+  switch (status) {
+    case "ACTIVE":
+      return "회원가입이 완료되었습니다.";
+    case "PENDING":
+      return "회원가입 요청이 완료되었습니다. 관리자 승인 후 이용할 수 있습니다.";
+    case "BLOCKED":
+      return "가입은 완료되었지만 차단된 계정입니다. 관리자에게 문의해주세요.";
+    case "SUSPENDED":
+      return "가입은 완료되었지만 정지된 계정입니다. 관리자에게 문의해주세요.";
+  }
+};
+
 export const LoginPage = () => {
   const router = useRouter();
   const [activeTab, setActiveTab] = useState("student");
+  const [companyMode, setCompanyMode] = useState<CompanyAuthMode>("login");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [signupValues, setSignupValues] = useState<CompanySignupValues>(initialCompanySignupValues);
   const [errorMessage, setErrorMessage] = useState("");
+  const [statusMessage, setStatusMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isStudent = activeTab === "student";
 
+  const handleCompanyModeChange = (nextMode: CompanyAuthMode) => {
+    setCompanyMode(nextMode);
+    setErrorMessage("");
+    setStatusMessage("");
+  };
+
+  const handleSignupValueChange = (name: keyof CompanySignupValues, value: string) => {
+    setSignupValues((currentValues) => ({
+      ...currentValues,
+      [name]: value,
+    }));
+  };
+
   const handleGoogleLoginClick = async () => {
     setErrorMessage("");
+    setStatusMessage("");
     setIsSubmitting(true);
 
     try {
@@ -55,6 +104,7 @@ export const LoginPage = () => {
     }
 
     setErrorMessage("");
+    setStatusMessage("");
     setIsSubmitting(true);
 
     try {
@@ -62,6 +112,58 @@ export const LoginPage = () => {
       router.replace("/home");
     } catch (error) {
       console.error("[auth] Company login failed", error);
+      setErrorMessage(getAuthErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCompanySignupSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const companyName = signupValues.companyName.trim();
+    const name = signupValues.name.trim();
+    const username = signupValues.username.trim();
+    const signupEmail = signupValues.email.trim();
+    const signupPassword = signupValues.password;
+    const passwordConfirm = signupValues.passwordConfirm;
+
+    if (!companyName || !name || !username || !signupEmail || !signupPassword || !passwordConfirm) {
+      setErrorMessage("모든 정보를 입력해주세요.");
+      return;
+    }
+
+    if (signupPassword.length < 6) {
+      setErrorMessage("비밀번호는 6자 이상으로 입력해주세요.");
+      return;
+    }
+
+    if (signupPassword !== passwordConfirm) {
+      setErrorMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+      return;
+    }
+
+    setErrorMessage("");
+    setStatusMessage("");
+    setIsSubmitting(true);
+
+    try {
+      const session = await signUpCompanyWithEmail(signupEmail, signupPassword, {
+        companyName,
+        name,
+      });
+      const nextMessage = getCompanySignupStatusMessage(session.backendUser.status);
+
+      setSignupValues(initialCompanySignupValues);
+      setEmail(signupEmail);
+      setPassword("");
+      setStatusMessage(nextMessage);
+
+      if (session.backendUser.status === "ACTIVE") {
+        router.replace("/home");
+      }
+    } catch (error) {
+      console.error("[auth] Company signup failed", error);
       setErrorMessage(getAuthErrorMessage(error));
     } finally {
       setIsSubmitting(false);
@@ -100,6 +202,7 @@ export const LoginPage = () => {
                     onChange={(nextTab) => {
                       setActiveTab(nextTab);
                       setErrorMessage("");
+                      setStatusMessage("");
                     }}
                     variant="horizontal"
                     isAnimated
@@ -109,7 +212,7 @@ export const LoginPage = () => {
 
                 <div className="login-page__body px-4 pb-8 pt-7 md:px-6 md:pb-[40px] md:pt-7">
                   <div
-                    key={activeTab}
+                    key={`${activeTab}-${companyMode}`}
                     className={[
                       "login-page__panel mx-auto flex w-full flex-col md:max-w-[672px]",
                       styles.panelAnimated,
@@ -123,13 +226,26 @@ export const LoginPage = () => {
                       />
                     ) : (
                       <CompanyLoginForm
+                        mode={companyMode}
                         email={email}
                         password={password}
+                        signupValues={signupValues}
                         isSubmitting={isSubmitting}
                         onEmailChange={setEmail}
                         onPasswordChange={setPassword}
-                        onSubmit={handleCompanyLoginSubmit}
+                        onSignupValueChange={handleSignupValueChange}
+                        onModeChange={handleCompanyModeChange}
+                        onLoginSubmit={handleCompanyLoginSubmit}
+                        onSignupSubmit={handleCompanySignupSubmit}
                       />
+                    )}
+                    {statusMessage && (
+                      <p
+                        role="status"
+                        className="mt-4 text-center text-[14px] font-medium leading-5 text-[var(--color-primary-800)]"
+                      >
+                        {statusMessage}
+                      </p>
                     )}
                     {errorMessage && (
                       <p

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -317,6 +317,69 @@ export const UserIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
   </svg>
 );
 
+// Building 아이콘 (기업/회사 입력용)
+export const BuildingIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <path
+      d="M3.33334 18.3333V4.99999C3.33334 4.07952 4.07953 3.33333 5 3.33333H11.6667C12.5871 3.33333 13.3333 4.07952 13.3333 4.99999V18.3333"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.3333 8.33333H15C15.9205 8.33333 16.6667 9.07952 16.6667 9.99999V18.3333"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M6.66666 6.66667H10M6.66666 10H10M6.66666 13.3333H10M1.66666 18.3333H18.3333"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+// AtSign 아이콘 (아이디 입력용)
+export const AtSignIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 20 20"
+    fill="none"
+    xmlns="http://www.w3.org/2000/svg"
+    {...props}
+  >
+    <circle
+      cx="10"
+      cy="10"
+      r="3.33333"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.3333 10V11.25C13.3333 12.4006 14.2661 13.3333 15.4167 13.3333C16.5673 13.3333 17.5 12.4006 17.5 11.25V10C17.5 5.85786 14.1421 2.5 10 2.5C5.85787 2.5 2.5 5.85786 2.5 10C2.5 14.1421 5.85787 17.5 10 17.5H13.3333"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 // Mail 아이콘 (예제용)
 export const MailIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
   <svg


### PR DESCRIPTION
## 🔎 What is this PR?

- 기업 로그인 탭 안에서 회원가입 폼 전환 구현
- Firebase 계정 생성과 백엔드 자동 회원가입 흐름 연결
- Closes #108

---

## 📝 Changes

- 기업 로그인 폼 하단 CTA 클릭 시 같은 기업 탭 카드 내부에서 회원가입 폼으로 전환
- 회원가입 입력 필드 추가: 회사명, 이름, 아이디, 이메일, 비밀번호, 비밀번호 확인
- Firebase `createUserWithEmailAndPassword` 기반 기업 계정 생성 후 `/api/auth/login` 호출
- 백엔드 요청에 `role: "COMPANY"`, 이름, 회사 정보 전달
- 승인 상태(`ACTIVE`, `PENDING`, `BLOCKED`, `SUSPENDED`)별 안내 메시지 표시
- 가입 오류 UX 보강: 이미 가입된 이메일, 약한 비밀번호, 비밀번호 확인 불일치
- 회사명/아이디 입력용 `BuildingIcon`, `AtSignIcon` 추가

---

## 📸 Screenshots (선택)

<img width="1540" height="1268" alt="image" src="https://github.com/user-attachments/assets/59f498df-7d4d-4cbd-a5e5-acf10c443ef7" />

---

## 📚 Background / Context (선택)

- 기존 기업 로그인 폼의 회원가입 CTA는 `#signup` 앵커만 제공
- 요청된 UX에 맞춰 탭과 카드 레이아웃은 유지하고 내부 입력 폼만 로그인/회원가입 모드로 전환
- 현재 백엔드 인증 요청 타입에 맞춰 담당자 이름은 `name`, 회사명은 `department`로 전달

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`, `pnpm exec prettier --check ...`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] Storybook 빌드 통과 (`pnpm exec storybook build --quiet`)
- [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
- [x] 주요 로직에 테스트 또는 검증 완료
