### PR TITLE
[Fix] #104 - 로그인 실패 에러 모달 미노출 수정

### DIFF
--- a/src/api/auth/auth-api.ts
+++ b/src/api/auth/auth-api.ts
@@ -15,13 +15,20 @@ export type BackendUser = {
   department: string;
 };
 
+type BackendLoginErrorOptions = {
+  status?: number;
+  payload?: unknown;
+};
+
 export class BackendLoginError extends Error {
   status?: number;
+  payload?: unknown;
 
-  constructor(message: string, status?: number) {
+  constructor(message: string, options: BackendLoginErrorOptions = {}) {
     super(message);
     this.name = "BackendLoginError";
-    this.status = status;
+    this.status = options.status;
+    this.payload = options.payload;
   }
 }
 
@@ -29,6 +36,32 @@ const getBackendApiBaseUrl = (): string => {
   const backendApiBaseUrl = process.env.NEXT_PUBLIC_BACKEND_API_BASE_URL ?? "";
 
   return backendApiBaseUrl.replace(/\/$/, "");
+};
+
+const parseErrorPayload = async (response: Response): Promise<unknown> => {
+  const contentType = response.headers.get("content-type") ?? "";
+
+  if (contentType.includes("application/json")) {
+    return response.json().catch(() => undefined);
+  }
+
+  return response.text().catch(() => undefined);
+};
+
+const getErrorMessage = (payload: unknown, status: number): string => {
+  if (payload && typeof payload === "object" && "message" in payload) {
+    const message = (payload as { message?: unknown }).message;
+
+    if (typeof message === "string" && message.trim()) {
+      return message;
+    }
+  }
+
+  if (typeof payload === "string" && payload.trim()) {
+    return payload;
+  }
+
+  return `Backend login failed. (${status})`;
 };
 
 export const loginWithBackend = async (
@@ -52,11 +85,12 @@ export const loginWithBackend = async (
   }
 
   if (!response.ok) {
-    const message = await response.text().catch(() => "");
-    throw new BackendLoginError(
-      message || `Backend login failed. (${response.status})`,
-      response.status,
-    );
+    const errorPayload = await parseErrorPayload(response);
+
+    throw new BackendLoginError(getErrorMessage(errorPayload, response.status), {
+      status: response.status,
+      payload: errorPayload,
+    });
   }
 
   return response.json() as Promise<BackendUser>;

--- a/src/lib/auth/auth-error-message.ts
+++ b/src/lib/auth/auth-error-message.ts
@@ -1,5 +1,11 @@
 import { BackendLoginError, GoogleProfileRoleError } from "@/api/auth";
 
+const hasServerMessage = (message: string): boolean => {
+  const trimmedMessage = message.trim();
+
+  return Boolean(trimmedMessage) && !trimmedMessage.startsWith("Backend login failed.");
+};
+
 export const getAuthErrorMessage = (error: unknown): string => {
   if (typeof error === "object" && error !== null && "code" in error) {
     const code = String(error.code);
@@ -25,12 +31,16 @@ export const getAuthErrorMessage = (error: unknown): string => {
   }
 
   if (error instanceof BackendLoginError) {
+    if (error.status === 400 && hasServerMessage(error.message)) {
+      return error.message;
+    }
+
     if (!error.status) {
       return "백엔드 서버에 연결할 수 없습니다. 서버 실행 상태와 CORS 설정을 확인해주세요.";
     }
 
     if (error.status === 401 || error.status === 403) {
-      return "백엔드에서 로그인 권한을 확인하지 못했습니다.";
+      return "로그인 인증을 확인하지 못했습니다. 다시 시도해주세요.";
     }
 
     return `백엔드 로그인 처리 중 문제가 발생했습니다. (${error.status})`;

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -9,7 +9,17 @@ import {
   signUpCompanyWithEmail,
 } from "@/lib/auth";
 import type { BackendUser } from "@/api/auth";
-import { Navigation, Tabs, type NavItem, type TabItem } from "@/shared/ui";
+import {
+  Button,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Navigation,
+  Tabs,
+  type NavItem,
+  type TabItem,
+} from "@/shared/ui";
 import {
   CompanyLoginForm,
   type CompanyAuthMode,
@@ -38,6 +48,11 @@ const initialCompanySignupValues: CompanySignupValues = {
   passwordConfirm: "",
 };
 
+type ErrorModalState = {
+  title: string;
+  message: string;
+};
+
 const getCompanySignupStatusMessage = (status: BackendUser["status"]): string => {
   switch (status) {
     case "ACTIVE":
@@ -58,16 +73,24 @@ export const LoginPage = () => {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [signupValues, setSignupValues] = useState<CompanySignupValues>(initialCompanySignupValues);
-  const [errorMessage, setErrorMessage] = useState("");
+  const [errorModal, setErrorModal] = useState<ErrorModalState | null>(null);
   const [statusMessage, setStatusMessage] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const isStudent = activeTab === "student";
 
+  const showErrorModal = (message: string, title = "로그인 실패") => {
+    setErrorModal({ title, message });
+  };
+
+  const clearFeedback = () => {
+    setErrorModal(null);
+    setStatusMessage("");
+  };
+
   const handleCompanyModeChange = (nextMode: CompanyAuthMode) => {
     setCompanyMode(nextMode);
-    setErrorMessage("");
-    setStatusMessage("");
+    clearFeedback();
   };
 
   const handleSignupValueChange = (name: keyof CompanySignupValues, value: string) => {
@@ -78,8 +101,7 @@ export const LoginPage = () => {
   };
 
   const handleGoogleLoginClick = async () => {
-    setErrorMessage("");
-    setStatusMessage("");
+    clearFeedback();
     setIsSubmitting(true);
 
     try {
@@ -87,7 +109,7 @@ export const LoginPage = () => {
       router.replace("/home");
     } catch (error) {
       console.error("[auth] Google login failed", error);
-      setErrorMessage(getAuthErrorMessage(error));
+      showErrorModal(getAuthErrorMessage(error));
     } finally {
       setIsSubmitting(false);
     }
@@ -99,12 +121,11 @@ export const LoginPage = () => {
     const trimmedEmail = email.trim();
 
     if (!trimmedEmail || !password) {
-      setErrorMessage("이메일과 비밀번호를 입력해주세요.");
+      showErrorModal("이메일과 비밀번호를 입력해주세요.", "입력 오류");
       return;
     }
 
-    setErrorMessage("");
-    setStatusMessage("");
+    clearFeedback();
     setIsSubmitting(true);
 
     try {
@@ -112,7 +133,7 @@ export const LoginPage = () => {
       router.replace("/home");
     } catch (error) {
       console.error("[auth] Company login failed", error);
-      setErrorMessage(getAuthErrorMessage(error));
+      showErrorModal(getAuthErrorMessage(error));
     } finally {
       setIsSubmitting(false);
     }
@@ -129,22 +150,21 @@ export const LoginPage = () => {
     const passwordConfirm = signupValues.passwordConfirm;
 
     if (!companyName || !name || !username || !signupEmail || !signupPassword || !passwordConfirm) {
-      setErrorMessage("모든 정보를 입력해주세요.");
+      showErrorModal("모든 정보를 입력해주세요.", "입력 오류");
       return;
     }
 
     if (signupPassword.length < 6) {
-      setErrorMessage("비밀번호는 6자 이상으로 입력해주세요.");
+      showErrorModal("비밀번호는 6자 이상으로 입력해주세요.", "입력 오류");
       return;
     }
 
     if (signupPassword !== passwordConfirm) {
-      setErrorMessage("비밀번호와 비밀번호 확인이 일치하지 않습니다.");
+      showErrorModal("비밀번호와 비밀번호 확인이 일치하지 않습니다.", "입력 오류");
       return;
     }
 
-    setErrorMessage("");
-    setStatusMessage("");
+    clearFeedback();
     setIsSubmitting(true);
 
     try {
@@ -164,7 +184,7 @@ export const LoginPage = () => {
       }
     } catch (error) {
       console.error("[auth] Company signup failed", error);
-      setErrorMessage(getAuthErrorMessage(error));
+      showErrorModal(getAuthErrorMessage(error), "회원가입 실패");
     } finally {
       setIsSubmitting(false);
     }
@@ -201,8 +221,7 @@ export const LoginPage = () => {
                     value={activeTab}
                     onChange={(nextTab) => {
                       setActiveTab(nextTab);
-                      setErrorMessage("");
-                      setStatusMessage("");
+                      clearFeedback();
                     }}
                     variant="horizontal"
                     isAnimated
@@ -247,14 +266,6 @@ export const LoginPage = () => {
                         {statusMessage}
                       </p>
                     )}
-                    {errorMessage && (
-                      <p
-                        role="alert"
-                        className="mt-4 text-center text-[14px] font-medium leading-5 text-[var(--color-error-500)]"
-                      >
-                        {errorMessage}
-                      </p>
-                    )}
                   </div>
                 </div>
               </div>
@@ -262,6 +273,29 @@ export const LoginPage = () => {
           </section>
         </div>
       </main>
+
+      <Modal
+        isOpen={errorModal !== null}
+        onClose={() => setErrorModal(null)}
+        className="max-w-[420px]"
+      >
+        <ModalHeader title={errorModal?.title ?? "오류"} onClose={() => setErrorModal(null)} />
+        <ModalContent>
+          <p className="text-[15px] font-medium leading-6 text-[var(--color-gray-700)]">
+            {errorModal?.message}
+          </p>
+        </ModalContent>
+        <ModalFooter>
+          <Button
+            type="button"
+            size="medium"
+            onClick={() => setErrorModal(null)}
+            className="rounded-[4px] hover:scale-100 active:scale-100"
+          >
+            확인
+          </Button>
+        </ModalFooter>
+      </Modal>
     </div>
   );
 };


### PR DESCRIPTION
## 🔎 What is this PR?

- 로그인 실패 안내를 공통 Modal UX로 전환
- Closes #104

---

## 📝 Changes

- Google 로그인/기업 로그인 실패 시 공통 Modal 노출
- 기업 로그인/회원가입 입력 검증 실패를 Modal로 안내
- 백엔드 로그인 실패 응답의 JSON message 파싱
- 401/403처럼 본문 없는 인증 실패 문구 정리
- 재시도/탭 전환/모드 전환 시 이전 피드백 초기화

---

## 📸 Screenshots (선택)

<img width="1700" height="970" alt="image" src="https://github.com/user-attachments/assets/949d9483-1352-44ab-9138-922678abc80a" />
<img width="1772" height="1080" alt="image" src="https://github.com/user-attachments/assets/a54f19ea-6d67-4d78-af38-6ce8801bb39d" />


---

## 📚 Background / Context (선택)

- 기존 로그인 실패 안내는 카드 하단 `p role="alert"` 인라인 텍스트로만 표시
- 실제 `/api/auth/login` 응답은 400 JSON message 또는 403 빈 응답 형태로 분기
- 서버 메시지가 있는 경우 그대로 안내하고, 본문 없는 인증 실패는 공통 문구로 처리

---

## ✔ Checklist

- [x] ESLint 통과 (`pnpm lint`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] 앱 빌드 통과 (`pnpm build`)
- [x] Playwright 정적 빌드 검증: 기업 로그인/회원가입 입력 누락 모달, 인라인 alert 제거, 탭 전환 시 모달 미노출
