### PR TITLE
[Feat] #114 - Navigation 공통 layout 적용

### DIFF
--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -16,17 +16,9 @@ const navigationItems: NavItem[] = [
 
 const headerlessRoutes = new Set(["/"]);
 
-const normalizePathname = (pathname: string | null): string => {
-  if (!pathname || pathname === "/") {
-    return "/";
-  }
-
-  return pathname.replace(/\/+$/, "");
-};
-
 export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
   const router = useRouter();
-  const pathname = normalizePathname(usePathname());
+  const pathname = usePathname();
   const shouldRenderNavigation = !headerlessRoutes.has(pathname);
 
   const handleLoginClick = () => {

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import type { ReactElement, ReactNode } from "react";
+import { usePathname, useRouter } from "next/navigation";
+import { Navigation, type NavItem } from "@/shared/ui";
+
+type AppLayoutProps = Readonly<{
+  children: ReactNode;
+}>;
+
+const navigationItems: NavItem[] = [
+  { label: "포트폴리오", href: "/portfolio" },
+  { label: "소개", href: "/about" },
+  { label: "공지사항", href: "/notice" },
+];
+
+const headerlessRoutes = new Set(["/"]);
+
+const normalizePathname = (pathname: string | null): string => {
+  if (!pathname || pathname === "/") {
+    return "/";
+  }
+
+  return pathname.replace(/\/+$/, "");
+};
+
+export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
+  const router = useRouter();
+  const pathname = normalizePathname(usePathname());
+  const shouldRenderNavigation = !headerlessRoutes.has(pathname);
+
+  const handleLoginClick = () => {
+    router.push("/login");
+  };
+
+  const handleSignupClick = () => {
+    router.push("/login");
+  };
+
+  return (
+    <>
+      {shouldRenderNavigation && (
+        <Navigation
+          items={navigationItems}
+          currentPathname={pathname}
+          logoHref="/home"
+          onLogin={handleLoginClick}
+          onSignup={handleSignupClick}
+        />
+      )}
+      {children}
+    </>
+  );
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { AppLayout } from "./app-layout";
 import "./globals.css";
 
 export const metadata: Metadata = {
@@ -21,7 +22,9 @@ type RootLayoutProps = Readonly<{
 export default function RootLayout({ children }: RootLayoutProps): React.ReactElement {
   return (
     <html lang="ko">
-      <body>{children}</body>
+      <body>
+        <AppLayout>{children}</AppLayout>
+      </body>
     </html>
   );
 }

--- a/src/screens/home/home.tsx
+++ b/src/screens/home/home.tsx
@@ -1,6 +1,6 @@
 export const HomePage: React.FC = () => {
   return (
-    <main className="min-h-screen bg-white px-6 py-10 text-[var(--color-gray-900)]">
+    <main className="min-h-[calc(100vh-80px)] bg-white px-6 py-10 text-[var(--color-gray-900)]">
       <section className="mx-auto flex max-w-[720px] flex-col gap-4">
         <p className="text-[14px] font-medium text-[var(--color-primary-800)]">로그인 완료</p>
         <h1 className="text-[32px] font-bold leading-tight text-black">AIM AJOU Home</h1>

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -15,9 +15,7 @@ import {
   ModalContent,
   ModalFooter,
   ModalHeader,
-  Navigation,
   Tabs,
-  type NavItem,
   type TabItem,
 } from "@/shared/ui";
 import {
@@ -27,12 +25,6 @@ import {
 } from "./company-login-form";
 import { StudentLoginPanel } from "./student-login-panel";
 import styles from "./login.module.css";
-
-const navItems: NavItem[] = [
-  { label: "포트폴리오", href: "#portfolio" },
-  { label: "소개", href: "#about" },
-  { label: "공지사항", href: "#notice" },
-];
 
 const loginTabs: TabItem[] = [
   { id: "student", label: "학생/교수" },
@@ -191,15 +183,8 @@ export const LoginPage = () => {
   };
 
   return (
-    <div className="login-page flex min-h-screen flex-col bg-white text-[var(--color-gray-900)]">
-      <Navigation
-        items={navItems}
-        onLogin={() => undefined}
-        onSignup={() => undefined}
-        className="login-page__nav"
-      />
-
-      <main className="login-page__main flex min-h-[calc(100vh-80px)] flex-1 justify-center px-2 pb-5 pt-[10vh] md:px-8 md:pb-10 md:pt-[8vh]">
+    <div className="login-page flex min-h-[calc(100vh-80px)] flex-col bg-white text-[var(--color-gray-900)]">
+      <main className="login-page__main flex flex-1 justify-center px-2 pb-5 pt-[10vh] md:px-8 md:pb-10 md:pt-[8vh]">
         <div className="flex w-full justify-center">
           <section className="login-page__surface w-full rounded-[24px] bg-[linear-gradient(180deg,#ffffff_0%,#fbfcff_100%)] py-0">
             <div className="login-page__content flex flex-col items-center">

--- a/src/shared/ui/navigation/navigation.tsx
+++ b/src/shared/ui/navigation/navigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useRef, useEffect } from "react";
+import Link from "next/link";
 import { Button } from "@/shared/ui/button/button";
 import { UserIcon, LogOutIcon } from "@/shared/ui/icons";
 
@@ -29,6 +30,7 @@ export type NavigationProps = {
   onProfileClick?: () => void;
   onAdminDashboardClick?: () => void;
   logoHref?: string;
+  currentPathname?: string;
   className?: string;
 };
 
@@ -56,6 +58,39 @@ const getNavLinkClasses = (isActive?: boolean) => {
     navLinkBaseClasses,
     isActive ? navLinkStatusClasses.active : navLinkStatusClasses.inactive,
   ].join(" ");
+};
+
+const normalizePathname = (href: string): string => {
+  const pathname = href.split(/[?#]/)[0] ?? "/";
+
+  if (!pathname.startsWith("/")) {
+    return pathname;
+  }
+
+  if (pathname === "/") {
+    return "/";
+  }
+
+  return pathname.replace(/\/+$/, "");
+};
+
+const getIsNavItemActive = (item: NavItem, currentPathname?: string): boolean => {
+  if (!currentPathname) {
+    return Boolean(item.isActive);
+  }
+
+  const itemPathname = normalizePathname(item.href);
+
+  if (!itemPathname.startsWith("/")) {
+    return Boolean(item.isActive);
+  }
+
+  const normalizedCurrentPathname = normalizePathname(currentPathname);
+
+  return (
+    normalizedCurrentPathname === itemPathname ||
+    normalizedCurrentPathname.startsWith(`${itemPathname}/`)
+  );
 };
 
 // 3. Admin Toggle Styles
@@ -98,6 +133,7 @@ export const Navigation = ({
   onProfileClick,
   onAdminDashboardClick,
   logoHref = "/",
+  currentPathname,
   className = "",
 }: NavigationProps) => {
   const [showProfile, setShowProfile] = useState(false);
@@ -121,7 +157,7 @@ export const Navigation = ({
     <header className={headerClasses}>
       <div className="mx-auto max-w-[1440px] h-full flex items-center justify-between">
         {/* Logo Section */}
-        <a href={logoHref} className="flex items-center shrink-0">
+        <Link href={logoHref} className="flex items-center shrink-0">
           <div className="relative h-12 w-12">
             <img
               src="/assets/aim-ajou-logo_text.svg"
@@ -129,14 +165,18 @@ export const Navigation = ({
               className="w-full h-full object-contain"
             />
           </div>
-        </a>
+        </Link>
 
         {/* Navigation Menu */}
         <nav className="flex items-center gap-12 h-full">
           {items.map((item) => (
-            <a key={item.href} href={item.href} className={getNavLinkClasses(item.isActive)}>
+            <Link
+              key={item.href}
+              href={item.href}
+              className={getNavLinkClasses(getIsNavItemActive(item, currentPathname))}
+            >
               {item.label}
-            </a>
+            </Link>
           ))}
         </nav>
 


### PR DESCRIPTION
## 🔎 What is this PR?

- App Router 공통 layout에서 `Navigation`을 한 번만 렌더링하도록 구조를 정리합니다.
- Closes #114

---

## 📝 Changes

- `src/app/app-layout.tsx` 추가: 공통 `Navigation`과 페이지 본문 `{children}` 렌더링 구조 분리
- 루트 `src/app/layout.tsx`에서 `AppLayout`을 통해 모든 페이지 본문 감싸기
- 로그인 화면에서 직접 렌더링하던 `Navigation`과 페이지별 nav item 제거
- `/home`, `/login` 본문 높이를 공통 헤더 기준으로 정리
- `Navigation` 링크를 Next `Link`로 변경
- `currentPathname` 기반 active menu 계산 추가
- 경로 정규화 책임을 `Navigation` active 계산 로직 한 곳으로 정리
- `/` 리다이렉트 전용 페이지는 headerless route로 예외 처리

---

## 📸 Screenshots (선택)

<img width="1356" height="517" alt="image" src="https://github.com/user-attachments/assets/235a85bd-51af-4b23-8d87-cd20a7d9be6a" />

---

## 📚 Background / Context (선택)

- 기존에는 페이지가 직접 `Navigation` 렌더링 여부를 결정할 수 있어 헤더 중복 삽입과 active 상태 관리가 분산될 여지가 있었습니다.
- Next.js App Router에서는 React Router의 `<Outlet />` 대신 layout의 `{children}`가 페이지 본문 슬롯 역할을 하므로, 해당 구조에 맞춰 `AppLayout`을 분리했습니다.
- 인증 상태를 Navigation에 반영하는 작업은 관련 이슈 #105에서 별도로 처리합니다.
- 페이지별 헤더 액션 확장(`headerSlot` 등)은 실제 요구사항이 생길 때 후속으로 열 수 있도록 이번 PR에서는 공통 렌더링 구조만 정리했습니다.

---

## ✔ Checklist

- [x] ESLint 통과 (`pnpm lint`)
- [x] 타입 체크 통과 (`pnpm exec tsc --noEmit`)
- [x] 앱 빌드 통과 (`pnpm build`)
- [x] 로컬 서버 응답 확인: `/login`, `/home` 모두 header 1개 렌더링
