### PR TITLE
[Feat] #105 - 로그인 성공 후 Navigation 로그인 상태 반영

### DIFF
--- a/src/api/auth/auth-api.ts
+++ b/src/api/auth/auth-api.ts
@@ -10,7 +10,7 @@ export type BackendUser = {
   userId: number;
   role: AuthRole;
   status: "ACTIVE" | "BLOCKED" | "SUSPENDED" | "PENDING";
-  adminRole: "NONE" | "ADMIN" | "SUPER_ADMIN";
+  adminRole: "NONE" | "ADMIN" | "SUPER_ADMIN" | null;
   name: string | null;
   department: string | null;
 };

--- a/src/api/auth/auth-api.ts
+++ b/src/api/auth/auth-api.ts
@@ -11,8 +11,8 @@ export type BackendUser = {
   role: AuthRole;
   status: "ACTIVE" | "BLOCKED" | "SUSPENDED" | "PENDING";
   adminRole: "NONE" | "ADMIN" | "SUPER_ADMIN";
-  name: string;
-  department: string;
+  name: string | null;
+  department: string | null;
 };
 
 type BackendLoginErrorOptions = {

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -18,18 +18,12 @@ const navigationItems: NavItem[] = [
 
 const headerlessRoutes = new Set(["/"]);
 
-const authRoleLabels: Partial<Record<string, NavUser["userType"]>> = {
+// 세션 파싱(normalizeStoredSession)이 role을 STUDENT/PROFESSOR/COMPANY로 보장하므로
+// 망라적 Record로 매핑한다. AuthRole에 새 역할이 추가되면 컴파일 에러로 누락을 잡는다.
+const authRoleLabels: Record<BackendUser["role"], NavUser["userType"]> = {
   STUDENT: "학생",
   PROFESSOR: "교수",
   COMPANY: "기업",
-};
-
-const getAuthRoleLabel = (
-  role: BackendUser["role"] | string | null | undefined,
-): NavUser["userType"] => {
-  if (!role) return "사용자";
-
-  return authRoleLabels[role] ?? "사용자";
 };
 
 export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
@@ -41,7 +35,7 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
     ? {
         name: session.name ?? session.email ?? "",
         email: session.email,
-        userType: getAuthRoleLabel(session.role),
+        userType: authRoleLabels[session.role],
         isAdmin: session.adminRole !== "NONE",
       }
     : undefined;

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -31,7 +31,7 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
   const shouldRenderNavigation = !headerlessRoutes.has(pathname);
   const navigationUser: NavUser | undefined = session
     ? {
-        name: session.name,
+        name: session.name ?? session.email ?? "",
         email: session.email,
         userType: authRoleLabels[session.role],
         isAdmin: session.adminRole !== "NONE",

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -2,7 +2,8 @@
 
 import type { ReactElement, ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { signOut, useAuthSession, type AuthRole } from "@/lib/auth";
+import { signOut, useAuthSession } from "@/lib/auth";
+import type { BackendUser } from "@/api/auth";
 import { Navigation, type NavItem, type NavUser } from "@/shared/ui";
 
 type AppLayoutProps = Readonly<{
@@ -17,7 +18,7 @@ const navigationItems: NavItem[] = [
 
 const headerlessRoutes = new Set(["/"]);
 
-const authRoleLabels: Record<AuthRole, NavUser["userType"]> = {
+const authRoleLabels: Record<BackendUser["role"], NavUser["userType"]> = {
   STUDENT: "학생",
   PROFESSOR: "교수",
   COMPANY: "기업",
@@ -30,10 +31,10 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
   const shouldRenderNavigation = !headerlessRoutes.has(pathname);
   const navigationUser: NavUser | undefined = session
     ? {
-        name: session.backendUser.name,
-        email: session.email ?? "",
-        userType: authRoleLabels[session.backendUser.role],
-        isAdmin: session.backendUser.adminRole !== "NONE",
+        name: session.name,
+        email: session.email,
+        userType: authRoleLabels[session.role],
+        isAdmin: session.adminRole !== "NONE",
       }
     : undefined;
 

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -2,7 +2,8 @@
 
 import type { ReactElement, ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { Navigation, type NavItem } from "@/shared/ui";
+import { signOut, useAuthSession, type AuthRole } from "@/lib/auth";
+import { Navigation, type NavItem, type NavUser } from "@/shared/ui";
 
 type AppLayoutProps = Readonly<{
   children: ReactNode;
@@ -16,10 +17,25 @@ const navigationItems: NavItem[] = [
 
 const headerlessRoutes = new Set(["/"]);
 
+const authRoleLabels: Record<AuthRole, NavUser["userType"]> = {
+  STUDENT: "학생",
+  PROFESSOR: "교수",
+  COMPANY: "기업",
+};
+
 export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
   const router = useRouter();
   const pathname = usePathname();
+  const { session, isAuthReady } = useAuthSession();
   const shouldRenderNavigation = !headerlessRoutes.has(pathname);
+  const navigationUser: NavUser | undefined = session
+    ? {
+        name: session.backendUser.name,
+        email: session.email ?? "",
+        userType: authRoleLabels[session.backendUser.role],
+        isAdmin: session.backendUser.adminRole !== "NONE",
+      }
+    : undefined;
 
   const handleLoginClick = () => {
     router.push("/login");
@@ -29,15 +45,26 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
     router.push("/login");
   };
 
+  const handleLogoutClick = async () => {
+    try {
+      await signOut();
+    } finally {
+      router.replace("/login");
+    }
+  };
+
   return (
     <>
       {shouldRenderNavigation && (
         <Navigation
           items={navigationItems}
           currentPathname={pathname}
+          user={navigationUser}
+          isAuthLoading={!isAuthReady}
           logoHref="/home"
           onLogin={handleLoginClick}
           onSignup={handleSignupClick}
+          onLogout={handleLogoutClick}
         />
       )}
       {children}

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -18,10 +18,18 @@ const navigationItems: NavItem[] = [
 
 const headerlessRoutes = new Set(["/"]);
 
-const authRoleLabels: Record<BackendUser["role"], NavUser["userType"]> = {
+const authRoleLabels: Partial<Record<string, NavUser["userType"]>> = {
   STUDENT: "학생",
   PROFESSOR: "교수",
   COMPANY: "기업",
+};
+
+const getAuthRoleLabel = (
+  role: BackendUser["role"] | string | null | undefined,
+): NavUser["userType"] => {
+  if (!role) return "사용자";
+
+  return authRoleLabels[role] ?? "사용자";
 };
 
 export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
@@ -33,7 +41,7 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
     ? {
         name: session.name ?? session.email ?? "",
         email: session.email,
-        userType: authRoleLabels[session.role],
+        userType: getAuthRoleLabel(session.role),
         isAdmin: session.adminRole !== "NONE",
       }
     : undefined;

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -22,6 +22,7 @@ import { clearAuthSession, saveAuthSession } from "./auth-session";
 type SessionResponse = {
   uid: string;
   email: string | null;
+  displayName: string | null;
   backendUser: BackendUser;
 };
 
@@ -51,6 +52,7 @@ const createSession = async (
   const session = {
     uid: firebaseUser.uid,
     email: firebaseUser.email,
+    displayName: firebaseUser.displayName,
     backendUser,
   };
 

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -6,6 +6,7 @@ import {
   signInWithEmailAndPassword,
   signInWithPopup,
   signOut as firebaseSignOut,
+  type User,
   updateProfile,
 } from "firebase/auth";
 import {
@@ -16,6 +17,7 @@ import {
   type BackendUser,
 } from "@/api/auth";
 import { auth } from "@/shared/config/firebase";
+import { clearAuthSession, saveAuthSession } from "./auth-session";
 
 type SessionResponse = {
   uid: string;
@@ -32,6 +34,7 @@ const googleProvider = new GoogleAuthProvider();
 GOOGLE_PROFILE_SCOPES.forEach((scope) => googleProvider.addScope(scope));
 
 const createSession = async (
+  firebaseUser: User,
   idToken: string,
   profile: BackendLoginRequest,
 ): Promise<SessionResponse> => {
@@ -41,14 +44,19 @@ const createSession = async (
     backendUser = await loginWithBackend(idToken, profile);
   } catch (error) {
     await firebaseSignOut(auth).catch(() => undefined);
+    clearAuthSession();
     throw error;
   }
 
-  return {
-    uid: auth.currentUser?.uid ?? "",
-    email: auth.currentUser?.email ?? null,
+  const session = {
+    uid: firebaseUser.uid,
+    email: firebaseUser.email,
     backendUser,
   };
+
+  saveAuthSession(session);
+
+  return session;
 };
 
 export const signInWithGoogle = async (): Promise<SessionResponse> => {
@@ -67,9 +75,10 @@ export const signInWithGoogle = async (): Promise<SessionResponse> => {
       fetchGoogleProfile(accessToken),
     ]);
 
-    return await createSession(idToken, profile);
+    return await createSession(credential.user, idToken, profile);
   } catch (error) {
     await firebaseSignOut(auth).catch(() => undefined);
+    clearAuthSession();
     throw error;
   }
 };
@@ -81,7 +90,7 @@ export const signInWithEmail = async (
   const credential = await signInWithEmailAndPassword(auth, email, password);
   const idToken = await credential.user.getIdToken();
 
-  return createSession(idToken, {
+  return createSession(credential.user, idToken, {
     role: "COMPANY",
     name: credential.user.displayName ?? credential.user.email ?? email,
     department: "",
@@ -101,7 +110,7 @@ export const signUpCompanyWithEmail = async (
 
   const idToken = await credential.user.getIdToken();
 
-  return createSession(idToken, {
+  return createSession(credential.user, idToken, {
     role: "COMPANY",
     name: profile.name,
     department: profile.companyName,
@@ -109,5 +118,9 @@ export const signUpCompanyWithEmail = async (
 };
 
 export const signOut = async (): Promise<void> => {
-  await firebaseSignOut(auth);
+  try {
+    await firebaseSignOut(auth);
+  } finally {
+    clearAuthSession();
+  }
 };

--- a/src/lib/auth/auth-service.ts
+++ b/src/lib/auth/auth-service.ts
@@ -78,7 +78,6 @@ export const signInWithGoogle = async (): Promise<SessionResponse> => {
     return await createSession(credential.user, idToken, profile);
   } catch (error) {
     await firebaseSignOut(auth).catch(() => undefined);
-    clearAuthSession();
     throw error;
   }
 };

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -33,7 +33,6 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
   if (
     typeof s.uid === "string" &&
     authRoles.has(s.role as BackendUser["role"]) &&
-    adminRoles.has(s.adminRole as BackendUser["adminRole"]) &&
     (typeof s.email === "string" || s.email === null)
   ) {
     return {
@@ -41,7 +40,9 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
       email: s.email,
       name: typeof s.name === "string" ? s.name : null,
       role: s.role as BackendUser["role"],
-      adminRole: s.adminRole as BackendUser["adminRole"],
+      adminRole: adminRoles.has(s.adminRole as BackendUser["adminRole"])
+        ? (s.adminRole as BackendUser["adminRole"])
+        : "NONE",
     };
   }
 
@@ -78,7 +79,7 @@ export const saveAuthSession = (session: AuthSession): void => {
     email: session.email,
     name: session.backendUser.name ?? null,
     role: session.backendUser.role,
-    adminRole: session.backendUser.adminRole,
+    adminRole: session.backendUser.adminRole ?? "NONE",
   };
 
   window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(toStore));

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -14,7 +14,7 @@ export type AuthSession = {
 export type StoredSession = {
   uid: string;
   email: string | null;
-  name: string;
+  name: string | null;
   role: BackendUser["role"];
   adminRole: BackendUser["adminRole"];
 };
@@ -32,7 +32,6 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
 
   if (
     typeof s.uid === "string" &&
-    typeof s.name === "string" &&
     authRoles.has(s.role as BackendUser["role"]) &&
     adminRoles.has(s.adminRole as BackendUser["adminRole"]) &&
     (typeof s.email === "string" || s.email === null)
@@ -40,7 +39,7 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
     return {
       uid: s.uid,
       email: s.email,
-      name: s.name,
+      name: typeof s.name === "string" ? s.name : null,
       role: s.role as BackendUser["role"],
       adminRole: s.adminRole as BackendUser["adminRole"],
     };
@@ -77,7 +76,7 @@ export const saveAuthSession = (session: AuthSession): void => {
   const toStore: StoredSession = {
     uid: session.uid,
     email: session.email,
-    name: session.backendUser.name,
+    name: session.backendUser.name ?? null,
     role: session.backendUser.role,
     adminRole: session.backendUser.adminRole,
   };

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -1,0 +1,181 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { onAuthStateChanged, type User } from "firebase/auth";
+import type { BackendUser } from "@/api/auth";
+import { auth } from "@/shared/config/firebase";
+
+export type AuthSession = {
+  uid: string;
+  email: string | null;
+  backendUser: BackendUser;
+};
+
+const AUTH_SESSION_STORAGE_KEY = "aim-auth-session";
+const AUTH_SESSION_EVENT = "aim-auth-session-changed";
+
+const authRoles: ReadonlySet<BackendUser["role"]> = new Set(["STUDENT", "PROFESSOR", "COMPANY"]);
+const authStatuses: ReadonlySet<BackendUser["status"]> = new Set([
+  "ACTIVE",
+  "BLOCKED",
+  "SUSPENDED",
+  "PENDING",
+]);
+const adminRoles: ReadonlySet<BackendUser["adminRole"]> = new Set(["NONE", "ADMIN", "SUPER_ADMIN"]);
+
+const normalizeBackendUser = (value: unknown): BackendUser | null => {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const user = value as Partial<BackendUser>;
+  const department = typeof user.department === "string" ? user.department : "";
+
+  if (
+    typeof user.userId === "number" &&
+    typeof user.name === "string" &&
+    authRoles.has(user.role as BackendUser["role"]) &&
+    authStatuses.has(user.status as BackendUser["status"]) &&
+    adminRoles.has(user.adminRole as BackendUser["adminRole"])
+  ) {
+    return {
+      userId: user.userId,
+      role: user.role as BackendUser["role"],
+      status: user.status as BackendUser["status"],
+      adminRole: user.adminRole as BackendUser["adminRole"],
+      name: user.name,
+      department,
+    };
+  }
+
+  return null;
+};
+
+const normalizeAuthSession = (value: unknown): AuthSession | null => {
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const session = value as Partial<AuthSession>;
+  const backendUser = normalizeBackendUser(session.backendUser);
+
+  if (
+    typeof session.uid === "string" &&
+    (typeof session.email === "string" || session.email === null) &&
+    backendUser
+  ) {
+    return {
+      uid: session.uid,
+      email: session.email,
+      backendUser,
+    };
+  }
+
+  return null;
+};
+
+const emitAuthSessionChanged = () => {
+  window.dispatchEvent(new Event(AUTH_SESSION_EVENT));
+};
+
+const readStoredAuthSession = (): AuthSession | null => {
+  const storedValue = window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY);
+
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsedValue: unknown = JSON.parse(storedValue);
+
+    return normalizeAuthSession(parsedValue);
+  } catch {
+    return null;
+  }
+};
+
+const normalizeSessionForStorage = (session: AuthSession): AuthSession => ({
+  ...session,
+  backendUser: {
+    ...session.backendUser,
+    department: session.backendUser.department ?? "",
+  },
+});
+
+const removeStoredAuthSession = (shouldNotify = true) => {
+  window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
+
+  if (shouldNotify) {
+    emitAuthSessionChanged();
+  }
+};
+
+export const saveAuthSession = (session: AuthSession): void => {
+  window.localStorage.setItem(
+    AUTH_SESSION_STORAGE_KEY,
+    JSON.stringify(normalizeSessionForStorage(session)),
+  );
+  emitAuthSessionChanged();
+};
+
+export const clearAuthSession = (): void => {
+  removeStoredAuthSession();
+};
+
+const getSessionForFirebaseUser = (firebaseUser: User): AuthSession | null => {
+  const storedSession = readStoredAuthSession();
+
+  if (!storedSession || storedSession.uid !== firebaseUser.uid) {
+    return null;
+  }
+
+  return {
+    ...storedSession,
+    email: storedSession.email ?? firebaseUser.email,
+  };
+};
+
+export const useAuthSession = (): {
+  session: AuthSession | null;
+  isAuthReady: boolean;
+} => {
+  const [session, setSession] = useState<AuthSession | null>(null);
+  const [isAuthReady, setIsAuthReady] = useState(false);
+
+  useEffect(() => {
+    const syncSession = (firebaseUser: User | null = auth.currentUser) => {
+      if (!firebaseUser) {
+        removeStoredAuthSession(false);
+        setSession(null);
+        setIsAuthReady(true);
+        return;
+      }
+
+      setSession(getSessionForFirebaseUser(firebaseUser));
+      setIsAuthReady(true);
+    };
+
+    const unsubscribeAuth = onAuthStateChanged(auth, syncSession);
+
+    const handleSessionChanged = () => {
+      syncSession();
+    };
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === AUTH_SESSION_STORAGE_KEY) {
+        syncSession();
+      }
+    };
+
+    window.addEventListener(AUTH_SESSION_EVENT, handleSessionChanged);
+    window.addEventListener("storage", handleStorageChange);
+
+    return () => {
+      unsubscribeAuth();
+      window.removeEventListener(AUTH_SESSION_EVENT, handleSessionChanged);
+      window.removeEventListener("storage", handleStorageChange);
+    };
+  }, []);
+
+  return { session, isAuthReady };
+};

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -8,6 +8,7 @@ import { auth } from "@/shared/config/firebase";
 export type AuthSession = {
   uid: string;
   email: string | null;
+  displayName: string | null;
   backendUser: BackendUser;
 };
 
@@ -25,6 +26,16 @@ const AUTH_SESSION_EVENT = "aim-auth-session-changed";
 const authRoles: ReadonlySet<BackendUser["role"]> = new Set(["STUDENT", "PROFESSOR", "COMPANY"]);
 const adminRoles: ReadonlySet<BackendUser["adminRole"]> = new Set(["NONE", "ADMIN", "SUPER_ADMIN"]);
 
+// 빈 문자열/공백 이름은 "없음"으로 취급해 이메일 fallback이 정상 동작하도록 정규화한다.
+// localStorage에서 온 unknown 값도 안전하게 처리한다(문자열이 아니면 null).
+const toDisplayName = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+
+  const trimmed = value.trim();
+
+  return trimmed ? trimmed : null;
+};
+
 const normalizeStoredSession = (value: unknown): StoredSession | null => {
   if (!value || typeof value !== "object") return null;
 
@@ -38,7 +49,7 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
     return {
       uid: s.uid,
       email: s.email,
-      name: typeof s.name === "string" ? s.name : null,
+      name: toDisplayName(s.name),
       role: s.role as BackendUser["role"],
       adminRole: adminRoles.has(s.adminRole as BackendUser["adminRole"])
         ? (s.adminRole as BackendUser["adminRole"])
@@ -77,7 +88,7 @@ export const saveAuthSession = (session: AuthSession): void => {
   const toStore: StoredSession = {
     uid: session.uid,
     email: session.email,
-    name: session.backendUser.name ?? null,
+    name: toDisplayName(session.backendUser.name) ?? toDisplayName(session.displayName),
     role: session.backendUser.role,
     adminRole: session.backendUser.adminRole ?? "NONE",
   };
@@ -98,6 +109,7 @@ const getStoredSessionForUser = (firebaseUser: User): StoredSession | null => {
   return {
     ...stored,
     email: stored.email ?? firebaseUser.email,
+    name: stored.name ?? toDisplayName(firebaseUser.displayName),
   };
 };
 

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -11,63 +11,38 @@ export type AuthSession = {
   backendUser: BackendUser;
 };
 
+export type StoredSession = {
+  uid: string;
+  email: string | null;
+  name: string;
+  role: BackendUser["role"];
+  adminRole: BackendUser["adminRole"];
+};
+
 const AUTH_SESSION_STORAGE_KEY = "aim-auth-session";
 const AUTH_SESSION_EVENT = "aim-auth-session-changed";
 
 const authRoles: ReadonlySet<BackendUser["role"]> = new Set(["STUDENT", "PROFESSOR", "COMPANY"]);
-const authStatuses: ReadonlySet<BackendUser["status"]> = new Set([
-  "ACTIVE",
-  "BLOCKED",
-  "SUSPENDED",
-  "PENDING",
-]);
 const adminRoles: ReadonlySet<BackendUser["adminRole"]> = new Set(["NONE", "ADMIN", "SUPER_ADMIN"]);
 
-const normalizeBackendUser = (value: unknown): BackendUser | null => {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
+const normalizeStoredSession = (value: unknown): StoredSession | null => {
+  if (!value || typeof value !== "object") return null;
 
-  const user = value as Partial<BackendUser>;
-  const department = typeof user.department === "string" ? user.department : "";
+  const s = value as Partial<StoredSession>;
 
   if (
-    typeof user.userId === "number" &&
-    typeof user.name === "string" &&
-    authRoles.has(user.role as BackendUser["role"]) &&
-    authStatuses.has(user.status as BackendUser["status"]) &&
-    adminRoles.has(user.adminRole as BackendUser["adminRole"])
+    typeof s.uid === "string" &&
+    typeof s.name === "string" &&
+    authRoles.has(s.role as BackendUser["role"]) &&
+    adminRoles.has(s.adminRole as BackendUser["adminRole"]) &&
+    (typeof s.email === "string" || s.email === null)
   ) {
     return {
-      userId: user.userId,
-      role: user.role as BackendUser["role"],
-      status: user.status as BackendUser["status"],
-      adminRole: user.adminRole as BackendUser["adminRole"],
-      name: user.name,
-      department,
-    };
-  }
-
-  return null;
-};
-
-const normalizeAuthSession = (value: unknown): AuthSession | null => {
-  if (!value || typeof value !== "object") {
-    return null;
-  }
-
-  const session = value as Partial<AuthSession>;
-  const backendUser = normalizeBackendUser(session.backendUser);
-
-  if (
-    typeof session.uid === "string" &&
-    (typeof session.email === "string" || session.email === null) &&
-    backendUser
-  ) {
-    return {
-      uid: session.uid,
-      email: session.email,
-      backendUser,
+      uid: s.uid,
+      email: s.email,
+      name: s.name,
+      role: s.role as BackendUser["role"],
+      adminRole: s.adminRole as BackendUser["adminRole"],
     };
   }
 
@@ -78,29 +53,17 @@ const emitAuthSessionChanged = () => {
   window.dispatchEvent(new Event(AUTH_SESSION_EVENT));
 };
 
-const readStoredAuthSession = (): AuthSession | null => {
+const readStoredSession = (): StoredSession | null => {
   const storedValue = window.localStorage.getItem(AUTH_SESSION_STORAGE_KEY);
 
-  if (!storedValue) {
-    return null;
-  }
+  if (!storedValue) return null;
 
   try {
-    const parsedValue: unknown = JSON.parse(storedValue);
-
-    return normalizeAuthSession(parsedValue);
+    return normalizeStoredSession(JSON.parse(storedValue));
   } catch {
     return null;
   }
 };
-
-const normalizeSessionForStorage = (session: AuthSession): AuthSession => ({
-  ...session,
-  backendUser: {
-    ...session.backendUser,
-    department: session.backendUser.department ?? "",
-  },
-});
 
 const removeStoredAuthSession = (shouldNotify = true) => {
   window.localStorage.removeItem(AUTH_SESSION_STORAGE_KEY);
@@ -111,10 +74,15 @@ const removeStoredAuthSession = (shouldNotify = true) => {
 };
 
 export const saveAuthSession = (session: AuthSession): void => {
-  window.localStorage.setItem(
-    AUTH_SESSION_STORAGE_KEY,
-    JSON.stringify(normalizeSessionForStorage(session)),
-  );
+  const toStore: StoredSession = {
+    uid: session.uid,
+    email: session.email,
+    name: session.backendUser.name,
+    role: session.backendUser.role,
+    adminRole: session.backendUser.adminRole,
+  };
+
+  window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(toStore));
   emitAuthSessionChanged();
 };
 
@@ -122,24 +90,22 @@ export const clearAuthSession = (): void => {
   removeStoredAuthSession();
 };
 
-const getSessionForFirebaseUser = (firebaseUser: User): AuthSession | null => {
-  const storedSession = readStoredAuthSession();
+const getStoredSessionForUser = (firebaseUser: User): StoredSession | null => {
+  const stored = readStoredSession();
 
-  if (!storedSession || storedSession.uid !== firebaseUser.uid) {
-    return null;
-  }
+  if (!stored || stored.uid !== firebaseUser.uid) return null;
 
   return {
-    ...storedSession,
-    email: storedSession.email ?? firebaseUser.email,
+    ...stored,
+    email: stored.email ?? firebaseUser.email,
   };
 };
 
 export const useAuthSession = (): {
-  session: AuthSession | null;
+  session: StoredSession | null;
   isAuthReady: boolean;
 } => {
-  const [session, setSession] = useState<AuthSession | null>(null);
+  const [session, setSession] = useState<StoredSession | null>(null);
   const [isAuthReady, setIsAuthReady] = useState(false);
 
   useEffect(() => {
@@ -151,7 +117,7 @@ export const useAuthSession = (): {
         return;
       }
 
-      setSession(getSessionForFirebaseUser(firebaseUser));
+      setSession(getStoredSessionForUser(firebaseUser));
       setIsAuthReady(true);
     };
 

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,4 +1,6 @@
 export { signInWithEmail, signInWithGoogle, signOut, signUpCompanyWithEmail } from "./auth-service";
+export { clearAuthSession, saveAuthSession, useAuthSession } from "./auth-session";
+export type { AuthSession } from "./auth-session";
 export { getAuthErrorMessage } from "./auth-error-message";
 export { useAuthReady, type AuthReadyState } from "./use-auth-ready";
 export type { AuthRole, BackendLoginRequest, BackendUser } from "@/api/auth";

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -1,6 +1,6 @@
 export { signInWithEmail, signInWithGoogle, signOut, signUpCompanyWithEmail } from "./auth-service";
 export { clearAuthSession, saveAuthSession, useAuthSession } from "./auth-session";
-export type { AuthSession } from "./auth-session";
+export type { AuthSession, StoredSession } from "./auth-session";
 export { getAuthErrorMessage } from "./auth-error-message";
 export { useAuthReady, type AuthReadyState } from "./use-auth-ready";
 export type { AuthRole, BackendLoginRequest, BackendUser } from "@/api/auth";

--- a/src/shared/ui/navigation/navigation.tsx
+++ b/src/shared/ui/navigation/navigation.tsx
@@ -15,7 +15,7 @@ export type NavItem = {
 export type NavUser = {
   name: string;
   email: string | null;
-  userType: "학생" | "기업" | "교수";
+  userType: "학생" | "기업" | "교수" | "사용자";
   isAdmin?: boolean;
 };
 

--- a/src/shared/ui/navigation/navigation.tsx
+++ b/src/shared/ui/navigation/navigation.tsx
@@ -14,7 +14,7 @@ export type NavItem = {
 
 export type NavUser = {
   name: string;
-  email: string;
+  email: string | null;
   userType: "학생" | "기업" | "교수";
   isAdmin?: boolean;
 };
@@ -231,9 +231,11 @@ export const Navigation = ({
                       <h3 className="text-[16px] font-bold text-[var(--color-gray-900,#111)] mb-1">
                         {user.name}
                       </h3>
-                      <p className="text-[14px] text-[var(--color-gray-600,#666)] mb-3">
-                        {user.email}
-                      </p>
+                      {user.email && (
+                        <p className="text-[14px] text-[var(--color-gray-600,#666)] mb-3">
+                          {user.email}
+                        </p>
+                      )}
                       <div className="inline-flex items-center px-3 py-1 rounded-full bg-[var(--color-primary-50)] text-[var(--color-primary-800,#004a9c)] text-[12px] font-semibold">
                         {user.userType}
                       </div>

--- a/src/shared/ui/navigation/navigation.tsx
+++ b/src/shared/ui/navigation/navigation.tsx
@@ -22,6 +22,7 @@ export type NavUser = {
 export type NavigationProps = {
   items: NavItem[];
   user?: NavUser;
+  isAuthLoading?: boolean;
   isAdminMode?: boolean;
   onAdminToggle?: () => void;
   onLogin?: () => void;
@@ -125,6 +126,7 @@ const getToggleHandleClasses = (isAdminMode: boolean) => {
 export const Navigation = ({
   items,
   user,
+  isAuthLoading = false,
   isAdminMode = false,
   onAdminToggle,
   onLogin,
@@ -198,7 +200,12 @@ export const Navigation = ({
             </div>
           )}
 
-          {user ? (
+          {isAuthLoading ? (
+            <div
+              className="h-10 w-[156px] animate-pulse rounded-[4px] bg-[var(--color-gray-100)]"
+              aria-label="인증 상태 확인 중"
+            />
+          ) : user ? (
             <div className="flex items-center gap-3 relative" ref={profileRef}>
               <button
                 onClick={() => setShowProfile(!showProfile)}

--- a/src/shared/ui/navigation/navigation.tsx
+++ b/src/shared/ui/navigation/navigation.tsx
@@ -15,7 +15,7 @@ export type NavItem = {
 export type NavUser = {
   name: string;
   email: string | null;
-  userType: "학생" | "기업" | "교수" | "사용자";
+  userType: "학생" | "기업" | "교수";
   isAdmin?: boolean;
 };
 
@@ -29,6 +29,7 @@ export type NavigationProps = {
   onSignup?: () => void;
   onLogout?: () => void;
   onProfileClick?: () => void;
+  onAccountSettingsClick?: () => void;
   onAdminDashboardClick?: () => void;
   logoHref?: string;
   currentPathname?: string;
@@ -133,6 +134,7 @@ export const Navigation = ({
   onSignup,
   onLogout,
   onProfileClick,
+  onAccountSettingsClick,
   onAdminDashboardClick,
   logoHref = "/",
   currentPathname,
@@ -267,6 +269,15 @@ export const Navigation = ({
                         className="text-left px-3 py-2.5 text-[14px] text-[var(--color-gray-900,#1a1a1a)] hover:bg-[var(--color-gray-100)] rounded-md transition-colors"
                       >
                         내 포트폴리오
+                      </button>
+                      <button
+                        onClick={() => {
+                          onAccountSettingsClick?.();
+                          setShowProfile(false);
+                        }}
+                        className="text-left px-3 py-2.5 text-[14px] text-[var(--color-gray-900,#1a1a1a)] hover:bg-[var(--color-gray-100)] rounded-md transition-colors"
+                      >
+                        계정 설정
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
## 🔎 What is this PR?

- 로그인 성공 시 백엔드 응답을 클라이언트 세션으로 저장하고, Navigation에 인증 상태를 반영합니다. closes #105

---

## 📝 Changes

- `src/lib/auth/auth-session.ts` — `localStorage` 기반 세션 관리 모듈 추가
  - `StoredSession` 타입: UI 표시에 필요한 필드만 저장 (`uid`, `email`, `name`, `role`, `adminRole`)
  - `saveAuthSession(session)` → `StoredSession` 필드만 직렬화하여 `localStorage` 저장
  - `clearAuthSession()` → 저장된 세션 삭제 + 동기화 이벤트 발행
  - `useAuthSession()` → Firebase `onAuthStateChanged` + 커스텀 이벤트 + `StorageEvent` 조합으로 같은 탭·다른 탭 세션 동기화
- `src/lib/auth/auth-service.ts` — 로그인·로그아웃 흐름에 세션 저장/삭제 연결
  - `createSession`: 백엔드 로그인 성공 시 `saveAuthSession` 호출; 실패 시 `clearAuthSession` 후 Firebase도 로그아웃
  - `signOut`: `try/finally`로 Firebase 실패 여부와 무관하게 `clearAuthSession` 보장
- `src/app/app-layout.tsx` — `useAuthSession`으로 세션 읽어 Navigation에 user props 매핑
  - `StoredSession` 필드 직접 참조 (`session.name`, `session.role`, `session.adminRole`, `session.email`)
  - `isAuthLoading={!isAuthReady}` 전달 → Firebase 초기화 전 스켈레톤 표시
  - `handleLogoutClick`: `signOut()` → `router.replace("/login")` (`finally`로 리다이렉트 보장)
- `src/shared/ui/navigation/navigation.tsx` — `isAuthLoading` prop 및 스켈레톤 UI 추가
  - `NavUser.email` 타입을 `string | null`로 확장; null이면 프로필 드롭다운 이메일 행 미노출

---

## 📸 Screenshots (선택)

<img width="588" height="704" alt="image" src="https://github.com/user-attachments/assets/6eb01725-9137-4856-bcc5-9297c410e519" />
---

## 📚 Background / Context (선택)

- 이 PR은 #114 공통 Navigation layout 브랜치 위에 쌓인 stacked PR입니다. #114가 먼저 merge된 뒤 base를 dev로 변경하면 diff가 #105 변경분만 남습니다.
- `localStorage` 저장 시 `userId`, `status`, `department` 같은 불필요한 필드를 제외하고 UI 표시용 필드만 직렬화합니다.
- 페이지 새로고침 시 Firebase가 비동기로 인증을 복원하는 동안 Navigation이 비로그인 버튼을 먼저 노출하는 깜빡임(FOUC)을 `isAuthLoading` 스켈레톤으로 방지합니다.

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
- [ ] 관련 문서/주석 반영 (필요 시)
- [ ] 주요 로직에 테스트 또는 검증 완료

---

## 🙏 Request

- `useAuthSession` 내 `syncSession` 기본 인자로 `auth.currentUser`를 사용하는 패턴이 의도한 대로 동작하는지 확인 부탁드립니다.
- 로그아웃 직후 `router.replace("/login")` 전에 Navigation이 잠시 비로그인 상태를 노출하는지 확인해 주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication sessions now persist across browser tabs and sessions for improved continuity.
  * Added loading indicator that displays during authentication sign-in and sign-out operations.
  * Added "Account Settings" option available in the user profile dropdown menu.
  * Enhanced user profile schema to support optional name and department fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->