### PR TITLE
[Fix] #139 - 배포 워크플로 pnpm/Node 셋업 추가

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -11,7 +11,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pnpm install --frozen-lockfile && pnpm build
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -13,7 +13,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pnpm install --frozen-lockfile && pnpm build
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
       - uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "frontend",
   "private": true,
   "version": "0.0.0",
+  "packageManager": "pnpm@10.20.0",
   "type": "module",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## 🔎 What is this PR?

- 배포/프리뷰 워크플로에 pnpm·Node 셋업을 추가해 CI 빌드 실패를 해소 (#136 블로커 5)

## 📝 Changes

- `firebase-hosting-merge.yml` / `firebase-hosting-pull-request.yml`: checkout 뒤에 `pnpm/action-setup@v4`(v10) + `actions/setup-node@v4`(node 20, `cache: pnpm`) 추가, install/build 스텝 분리
- `package.json`: `packageManager: pnpm@10.20.0` 추가
- deploy 액션·secrets·트리거는 변경하지 않음

## ⚠️ 참고

- merge 워크플로는 `push: main` 트리거 유지
  - **main 브랜치 생성 시점에 라이브 배포가 시작**됩니다. main 생성/배포는 별도 결정 후 진행 권장
- 이 PR 머지 후 프리뷰 워크플로가 PR마다 동작하기 시작합니다(동일 레포 PR 한정)

## 🔗 관련

- #139, #136

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflows to use a consistent Node.js and pnpm setup before building.
  * Split install and build into separate steps for clearer, more reliable CI runs.
  * Pinned the package manager version to ensure consistent installs across environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->