### PR TITLE
[Feat] #138 - 기업 회원가입 아이디 필드 제거

### DIFF
--- a/src/screens/login/company-login-form.tsx
+++ b/src/screens/login/company-login-form.tsx
@@ -1,12 +1,11 @@
 import { Button, Input } from "@/shared/ui";
-import { AtSignIcon, BuildingIcon, LockIcon, MailIcon, UserIcon } from "@/shared/ui/icons";
+import { BuildingIcon, LockIcon, MailIcon, UserIcon } from "@/shared/ui/icons";
 
 export type CompanyAuthMode = "login" | "signup";
 
 export type CompanySignupValues = {
   companyName: string;
   name: string;
-  username: string;
   email: string;
   password: string;
   passwordConfirm: string;
@@ -69,20 +68,6 @@ export const CompanyLoginForm = ({
           placeholder="이름"
           aria-label="이름"
           leftIcon={<UserIcon width={20} />}
-          iconClassName={iconClassName}
-          size="large"
-          isFullWidth
-          className={signupInputClassName}
-        />
-        <Input
-          id="company-signup-username"
-          type="text"
-          value={signupValues.username}
-          onChange={(event) => onSignupValueChange("username", event.target.value)}
-          disabled={isSubmitting}
-          placeholder="아이디"
-          aria-label="아이디"
-          leftIcon={<AtSignIcon width={20} />}
           iconClassName={iconClassName}
           size="large"
           isFullWidth

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -36,7 +36,6 @@ const loginTabs: TabItem[] = [
 const initialCompanySignupValues: CompanySignupValues = {
   companyName: "",
   name: "",
-  username: "",
   email: "",
   password: "",
   passwordConfirm: "",
@@ -138,12 +137,11 @@ export const LoginPage = () => {
 
     const companyName = signupValues.companyName.trim();
     const name = signupValues.name.trim();
-    const username = signupValues.username.trim();
     const signupEmail = signupValues.email.trim();
     const signupPassword = signupValues.password;
     const passwordConfirm = signupValues.passwordConfirm;
 
-    if (!companyName || !name || !username || !signupEmail || !signupPassword || !passwordConfirm) {
+    if (!companyName || !name || !signupEmail || !signupPassword || !passwordConfirm) {
       showErrorModal("모든 정보를 입력해주세요.", "입력 오류");
       return;
     }


### PR DESCRIPTION
## 🔎 What is this PR?

- 기업 회원가입 폼의 "아이디"(username) 필드 제거 (#138)

## 📝 Changes

- `company-login-form.tsx`: `CompanySignupValues`에서 `username` 제거, 아이디 `Input` 블록 제거, 미사용 `AtSignIcon` import 정리
- `index.tsx`: `initialCompanySignupValues`의 `username` 제거, trim/필수값 검증에서 제거
- 제출 로직은 기존과 동일(`{ companyName, name }` 전송)

## 💡 배경

이메일+비밀번호 인증 체계에서 로그인 식별자는 이메일입니다. 아이디는 입력·검증만 되고 어디에도 저장/전송되지 않아(백엔드 `LoginRequest`에도 필드 없음) 사용자 오해를 유발할 수 있어 제거합니다.

## ✅ 검증

- `pnpm build` 통과 (username 잔존 참조 0)

## 🔗 관련

- #138

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated company sign-up so it no longer asks for a username.
  * Simplified the required fields check for company registration to match the current form.
  * Kept email, password, and password confirmation validation intact while preserving the existing sign-up flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->