### PR TITLE
[Feat] #144 - 공용 Loading 컴포넌트 및 페이지 전환 애니메이션 구현

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -277,4 +277,82 @@ body {
   .animate-shimmer {
     animation: shimmer 1.5s infinite;
   }
+
+  /* 로딩 점 물결 바운스 (Loading 컴포넌트) */
+  @keyframes wave-bounce {
+    0%, 60%, 100% { transform: translateY(0); }
+    30% { transform: translateY(-60%); }
+  }
+  .animate-wave-bounce {
+    animation: wave-bounce 1.2s ease-in-out infinite;
+  }
+
+  /* 전체 화면 로딩 배경 판: 화면을 통째로 덮는 솔리드.
+     윗변은 SVG 2차 베지어(Q)로 그려, 가운데 컨트롤 포인트의 Y만 움직여 곡률을 만든다.
+     (border-radius 로 둥글리는 게 아니라, 직선 가운데를 실로 당기듯 위로 볼록하게 하는 방식)
+
+     lift: 윗변이 화면 위로 빠져나간 뒤에 감속(ease-in 꼬리)이 끝나도록 주는 여유 높이. */
+  .loading-panel {
+    --loading-panel-lift: 12vh;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: calc(100% + var(--loading-panel-lift));
+  }
+  /* preserveAspectRatio="none" + overflow visible → 곡선이 뷰박스 위로 볼록해져도 잘리지 않고 늘어난다 */
+  .loading-panel-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+  /* Firefox 등 CSS `d` 애니메이션 미지원 브라우저는 이 곡선 d(리딩 아치)로 고정 표시. */
+  .loading-panel-fill {
+    d: path("M 0 0 Q 50 -22 100 0 L 100 100 L 0 100 Z");
+  }
+
+  /* 전체 화면 로딩 진입 (Loading 컴포넌트 isFullScreen)
+     솔리드가 아래에서 한 번 올라와 이전 화면을 덮고 그대로 머무른다(반복 없음).
+
+     핵심: 상승(translateY)과 곡률(d)에 '같은 duration·같은 timing-function'을 줘서
+     매 순간 곡률 진행률 = 상승 진행률이 되도록 동기화한다.
+     → 느리게 출발할 땐 거의 직선, 속도가 붙을수록 아치가 함께 자란다(툭 튀지 않음).
+     정착 시 아치 코너(y=0)는 lift 만큼 화면 위로 빠져나가 화면은 평평하게 덮인다. */
+  @keyframes panel-cover {
+    from { transform: translateY(100%); }
+    to   { transform: translateY(0); }
+  }
+  @keyframes panel-curve {
+    from { d: path("M 0 0 Q 50 0 100 0 L 100 100 L 0 100 Z"); }
+    to   { d: path("M 0 0 Q 50 -22 100 0 L 100 100 L 0 100 Z"); }
+  }
+  .animate-panel-cover {
+    /* ease-in (가속): 처음엔 천천히 밀려 올라오다 끝으로 갈수록 훅 빨라지며 덮는다 (텐션 유지, 속도만 ↑) */
+    animation: panel-cover 0.6s cubic-bezier(0.55, 0, 0.85, 0.3) forwards;
+  }
+  .animate-panel-cover .loading-panel-fill {
+    /* 상승과 완전히 동일한 타이밍 — 곡률이 이동량에 1:1로 붙어 따로 놀지 않는다 */
+    animation: panel-curve 0.6s cubic-bezier(0.55, 0, 0.85, 0.3) forwards;
+  }
+
+  /* 문구·점은 아치가 화면을 덮은 뒤에 떠오른다 (backwards: 지연 동안 숨김) */
+  @keyframes loading-content-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .animate-loading-content-in {
+    /* 아치가 화면을 덮은 직후(≈0.55s) 문구·점이 떠오르도록 지연을 상승 속도에 맞춰 당김 */
+    animation: loading-content-in 0.3s ease-out 0.5s backwards;
+  }
+
+  /* 모션 민감 사용자 배려: 로딩 모션 정지 (판은 덮은 상태, 콘텐츠는 보이는 상태로 고정) */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-wave-bounce,
+    .animate-panel-cover,
+    .animate-panel-cover .loading-panel-fill,
+    .animate-loading-content-in {
+      animation: none;
+    }
+  }
 }

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -8,6 +8,8 @@ export { Navigation } from "./navigation/navigation";
 export type { NavigationProps, NavItem, NavUser } from "./navigation/navigation";
 export { Footer } from "./footer/footer";
 export type { FooterProps, FooterLink } from "./footer/footer";
+export { Loading } from "./loading";
+export type { LoadingProps, LoadingSize } from "./loading";
 
 // Form components
 export * from "./form";

--- a/src/shared/ui/loading/index.ts
+++ b/src/shared/ui/loading/index.ts
@@ -1,0 +1,2 @@
+export { Loading } from "./loading";
+export type { LoadingProps, LoadingSize } from "./loading";

--- a/src/shared/ui/loading/loading.stories.tsx
+++ b/src/shared/ui/loading/loading.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Loading } from "./loading";
+
+const meta = {
+  title: "Shared/UI/Loading",
+  component: Loading,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["small", "medium", "large"],
+    },
+    isFullScreen: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    text: "불러오는 중...",
+    size: "medium",
+  },
+};
+
+export const PortfolioSearch: Story = {
+  args: {
+    text: "최적의 포트폴리오를 찾는 중...",
+    size: "medium",
+  },
+};
+
+export const DotsOnly: Story = {
+  args: {
+    size: "medium",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    text: "불러오는 중...",
+    size: "small",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    text: "최적의 포트폴리오를 찾는 중...",
+    size: "large",
+  },
+};
+
+export const FullScreen: Story = {
+  args: {
+    text: "페이지를 불러오는 중...",
+    size: "large",
+    isFullScreen: true,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+};

--- a/src/shared/ui/loading/loading.tsx
+++ b/src/shared/ui/loading/loading.tsx
@@ -1,0 +1,121 @@
+export type LoadingSize = "small" | "medium" | "large";
+
+export interface LoadingProps {
+  /** 로딩 중 표시할 문구 (페이지마다 다르게 주입). 없으면 점만 표시 */
+  text?: string;
+  size?: LoadingSize;
+  /** 전체 화면 오버레이로 표시 (페이지 이동 시 사용) */
+  isFullScreen?: boolean;
+  className?: string;
+}
+
+// 점마다 아주 블루 팔레트를 진 → 연으로 (물결 색상 그라데이션). 밝은 배경(인라인)용
+const dotColorClasses = [
+  "bg-[color:var(--color-primary-800,#004A9C)]",
+  "bg-[color:var(--color-primary-600,#0066CC)]",
+  "bg-[color:var(--color-primary-400,#5C9DE5)]",
+] as const;
+
+// 전체 화면은 진한 블루 아치 위에 얹히므로, 점도 밝은 톤(흰색 → 하늘색)으로 뒤집는다
+const dotColorClassesOnCover = [
+  "bg-white",
+  "bg-[color:var(--color-primary-100,#E0EDFB)]",
+  "bg-[color:var(--color-primary-300,#85B5EE)]",
+] as const;
+
+const dotSizeClasses: Record<LoadingSize, string> = {
+  small: "h-1.5 w-1.5",
+  medium: "h-2.5 w-2.5",
+  large: "h-3.5 w-3.5",
+};
+
+const gapClasses: Record<LoadingSize, string> = {
+  small: "gap-1",
+  medium: "gap-1.5",
+  large: "gap-2",
+};
+
+const textSizeClasses: Record<LoadingSize, string> = {
+  small: "text-[12px] leading-[16px]",
+  medium: "text-[14px] leading-[20px]",
+  large: "text-[16px] leading-[24px]",
+};
+
+// 전체 화면에서 화면을 덮는 솔리드의 색(SVG path fill). 색만 바꾸려면 여기만 수정하면 된다.
+const coverPanelColor = "var(--color-primary-800,#004A9C)";
+
+// 전체 화면에서는 진한 블루 판 위에 글자가 얹히므로, 회색 대신 흰색으로 대비를 확보한다
+const getTextClasses = (size: LoadingSize, isFullScreen: boolean) =>
+  [
+    isFullScreen
+      ? "font-semibold text-white"
+      : "font-medium text-[color:var(--color-gray-700,#4D4D4D)]",
+    textSizeClasses[size],
+  ].join(" ");
+
+export const Loading = ({
+  text,
+  size = "medium",
+  isFullScreen = false,
+  className = "",
+}: LoadingProps) => {
+  const containerClasses = isFullScreen
+    ? "fixed inset-0 z-[var(--z-modal,1050)] flex items-center justify-center overflow-hidden"
+    : "inline-flex items-center justify-center";
+
+  // 아치 솔리드는 z-0, 문구·점은 z-10 → 덮개가 항상 콘텐츠 뒤에 깔린다
+  const contentClasses = [
+    "relative flex flex-col items-center justify-center gap-3",
+    isFullScreen ? "z-10 animate-loading-content-in" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const dotsWrapperClasses = ["flex items-end", gapClasses[size]].join(" ");
+
+  const dotBaseClasses = [
+    "inline-block rounded-full animate-wave-bounce",
+    dotSizeClasses[size],
+  ].join(" ");
+
+  const dots = isFullScreen ? dotColorClassesOnCover : dotColorClasses;
+
+  return (
+    <div className={containerClasses} role="status" aria-live="polite" aria-busy="true">
+      {isFullScreen && (
+        // 솔리드가 아래에서 한 번 올라와 이전 화면을 덮는다 (반복 없음).
+        // 윗변은 SVG 2차 베지어 — 가운데 컨트롤 포인트를 당겨 곡률을 만들었다가 마지막에 편다.
+        <div className="loading-panel animate-panel-cover z-0" aria-hidden="true">
+          <svg className="loading-panel-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <path
+              className="loading-panel-fill"
+              fill={coverPanelColor}
+              d="M 0 0 Q 50 0 100 0 L 100 100 L 0 100 Z"
+            />
+          </svg>
+        </div>
+      )}
+
+      <div className={contentClasses}>
+        {text && <p className={getTextClasses(size, isFullScreen)}>{text}</p>}
+
+        <div className={dotsWrapperClasses} aria-hidden="true">
+          {dots.map((colorClass, index) => (
+            <span
+              key={index}
+              className={`${dotBaseClasses} ${colorClass}`}
+              // 0.15s씩 순차 지연 → 물결 파동 (인라인 스타일이 shorthand animation 을 확실히 덮어씀)
+              style={{ animationDelay: `${index * 0.15}s` }}
+            />
+          ))}
+        </div>
+
+        {/* text 가 없을 때 스크린리더용 대체 문구 */}
+        {!text && <span className="sr-only">불러오는 중</span>}
+      </div>
+    </div>
+  );
+};
+
+Loading.displayName = "Loading";


### PR DESCRIPTION
## 🔎 What is this PR?

- 페이지 이동/데이터 로딩 시 사용할 공용 Loading 컴포넌트와 전체 화면 페이지 전환 애니메이션 추가

---

## 📝 Changes

- `shared/ui/loading` 컴포넌트 신규 (`text` / `size` / `isFullScreen`)
- 인라인 모드: Ajou Blue 점 물결(wave) 로더
- 전체 화면 모드: 솔리드 패널이 아래에서 한 번 올라와 이전 화면을 덮는 전환(1회·유지)
- 윗변은 SVG 2차 베지어로, 상승 이동량과 곡률을 동일 타이밍으로 1:1 동기화(툭 튀는 팝 제거)
- 접근성: `prefers-reduced-motion` 정지 대응, `role="status"` / `aria-live`
- Storybook 스토리 추가 (`loading.stories.tsx`)
- `shared/ui/index.ts` public export 추가

---

## 📸 Screenshots (선택)

- 전체 화면 전환: 아치 솔리드가 아래에서 올라와 이전 화면을 덮은 뒤 문구·점이 표시됨 (로컬 헤드리스 렌더로 프레임별 검증 완료)

---

## 📚 Background / Context (선택)

- #144
- #134(초기 로딩 속도 개선)의 체감 개선 맥락 — 로딩 대기 구간에 일관된 브랜드 톤의 전환 연출 제공

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`) — 변경 파일 기준 클린 (아래 Request 참고)
- [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
- [x] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료

---

## 🙏 Request

- 전체 화면 전환의 속도(0.6s)·곡률(베지어 -22) 톤이 적절한지 확인 부탁드립니다.
- 참고: 본 PR과 무관한 사전 존재 ESLint 에러가 `src/screens/portfolio/portfolio-page.tsx:53`(#120 유입, `react-hooks/refs`)에 있어 프로젝트 전체 `pnpm lint`/CI ESLint가 실패할 수 있습니다. 별도 이슈로 처리 필요.
