### PR TITLE
[Fix] #153 - 포스트 카드 호버 영역/모서리 어긋남 수정

### DIFF
--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -117,7 +117,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
       ? "transition-colors duration-200 ease-out group-hover:border-[var(--color-primary-500,#3385DB)]"
       : "";
 
-    const wrapperClasses = `flex w-full min-w-[280px] max-w-[360px] flex-col group ${linkedHoverClasses} ${
+    const wrapperClasses = `flex w-full min-w-[280px] max-w-[360px] self-start rounded-xl flex-col group ${linkedHoverClasses} ${
       href || onClick ? "cursor-pointer" : ""
     } ${className}`;
 


### PR DESCRIPTION
## 🔎 What is this PR?

- 포스트 카드의 호버 영역이 개별 카드 높이에 맞지 않고, 호버 그림자가 둥근 모서리를 벗어나던 문제 수정 (#153)

## 📝 Changes

- `src/shared/ui/card/card.tsx`: `PostCardContent`의 `wrapperClasses`에 `self-start rounded-xl` 추가
  - `self-start` — 카드 wrapper(`<Link>`)가 grid item이라 기본값 `stretch`로 같은 행에서 가장 높은 카드 높이까지 늘어났습니다. 안쪽 두 div는 `flex-col`에서 `flex-1`이 없어 콘텐츠 높이 그대로라, 늘어난 만큼 카드 아래가 빈 채로 호버 영역이 됐습니다
  - `rounded-xl` — 둥근 모서리가 자식(`rounded-t-xl` / `rounded-b-xl`)에만 있고 wrapper에는 없어서, wrapper에 걸린 `hover:shadow-...`가 직각 박스 기준으로 그려졌습니다
- 사용처(홈 게시글/공지 섹션, 포트폴리오 목록)가 모두 같은 `grid grid-cols-... gap-6` 구조라 공용 `Card` 한 곳에서 처리했습니다. grid 컨테이너 3곳에 `items-start`를 넣거나 prop을 새로 파는 방식은 택하지 않았습니다

## ✅ 검증

헤드리스 Chrome(CDP)으로 실제 렌더링을 측정했습니다. `slack`은 카드 콘텐츠 아래에 남는 빈 호버 영역입니다.

| | 빈 호버 영역(max) | 그림자 radius | `align-self` |
| --- | --- | --- | --- |
| 수정 전 (dev) | **42px** | `0px` | `auto` |
| 수정 후 `/home` | **0** | `16px` | `flex-start` |
| 수정 후 `/portfolio` | **0** | `16px` | `flex-start` |

- 같은 행에 높이 352.8px / 394.7px 카드가 함께 있는 것을 확인해, 이슈의 전제(행 내 카드 높이 차이)가 실제로 발생함을 같이 검증했습니다
- 카드 자체의 보이는 높이는 변하지 않습니다. 기존에도 흰 본문 영역은 콘텐츠 높이였고, 늘어나 있던 건 투명한 wrapper 박스뿐이라 `self-start`는 그 박스만 줄입니다
- `tsc --noEmit` 통과, `eslint src/shared/ui/card/card.tsx` 클린
- 다른 사용처인 `/portfolio` 회귀 없음

## 🔗 관련

- #153


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved post card alignment so cards consistently start at the top of their container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->