### PR TITLE
[Release] dev → main 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ sb-*.log
 package-lock.json.claude/
 GEMINI.md
 /test-results.claude/
+
+# Local environment variables
+.env.local

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1240,105 +1240,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1417,28 +1401,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.1':
     resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.1':
     resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.1':
     resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.1':
     resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
@@ -1558,67 +1538,56 @@ packages:
     resolution: {integrity: sha512-EPlb95nUsz6Dd9Qy13fI5kUPXNSljaG9FiJ4YUGU1O/Q77i5DYFW5KR8g1OzTcdZUqQQ1KdDqsTohdFVwCwjqg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.2':
     resolution: {integrity: sha512-BOmnVW+khAUX+YZvNfa0tGTEMVVEerOxN0pDk2E6N6DsEIa2Ctj48FOMfNDdrwinocKaC7YXUZ1pHlKpnkja/Q==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.2':
     resolution: {integrity: sha512-Xt2byDZ+6OVNuREgBXr4+CZDJtrVso5woFtpKdGPhpTPHcNG7D8YXeQzpNbFRxzTVqJf7kvPMCub/pcGUWgBjA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.2':
     resolution: {integrity: sha512-+LdZSldy/I9N8+klim/Y1HsKbJ3BbInHav5qE9Iy77dtHC/pibw1SR/fXlWyAk0ThnpRKoODwnAuSjqxFRDHUQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.2':
     resolution: {integrity: sha512-8ms8sjmyc1jWJS6WdNSA23rEfdjWB30LH8Wqj0Cqvv7qSHnvw6kgMMXRdop6hkmGPlyYBdRPkjJnj3KCUHV/uQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.2':
     resolution: {integrity: sha512-3HRQLUQbpBDMmzoxPJYd3W6vrVHOo2cVW8RUo87Xz0JPJcBLBr5kZ1pGcQAhdZgX9VV7NbGNipah1omKKe23/g==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.2':
     resolution: {integrity: sha512-fMjKi+ojnmIvhk34gZP94vjogXNNUKMEYs+EDaB/5TG/wUkoeua7p7VCHnE6T2Tx+iaghAqQX8teQzcvrYpaQA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.2':
     resolution: {integrity: sha512-XuGFGU+VwUUV5kLvoAdi0Wz5Xbh2SrjIxCtZj6Wq8MDp4bflb/+ThZsVxokM7n0pcbkEr2h5/pzqzDYI7cCgLQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.2':
     resolution: {integrity: sha512-w6yjZF0P+NGzWR3AXWX9zc0DNEGdtvykB03uhonSHMRa+oWA6novflo2WaJr6JZakG2ucsyb+rvhrKac6NIy+w==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.2':
     resolution: {integrity: sha512-yo8d6tdfdeBArzC7T/PnHd7OypfI9cbuZzPnzLJIyKYFhAQ8SvlkKtKBMbXDxe1h03Rcr7u++nFS7tqXz87Gtw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.2':
     resolution: {integrity: sha512-ah59c1YkCxKExPP8O9PwOvs+XRLKwh/mV+3YdKqQ5AMQ0r4M4ZDuOrpWkUaqO7fzAHdINzV9tEVu8vNw48z0lA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.2':
     resolution: {integrity: sha512-4VEd19Wmhr+Zy7hbUsFZ6YXEiP48hE//KPLCSVNY5RMGX2/7HZ+QkN55a3atM1C/BZCGIgqN+xrVgtdak2S9+A==}
@@ -1790,28 +1759,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -2236,49 +2201,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -3825,28 +3782,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}

--- a/src/api/cache.ts
+++ b/src/api/cache.ts
@@ -1,0 +1,47 @@
+// 목록 GET 응답용 경량 클라이언트 캐시
+// - TTL 동안 동일 요청은 네트워크 없이 재사용 → 홈↔목록↔뒤로가기 재진입 시 재요청 제거
+// - in-flight 요청 dedup → 같은 키의 동시 호출(홈 섹션/중복 진입)을 한 번의 네트워크로 합침
+// 모듈 레벨 Map이라 전체 새로고침 시 초기화된다(정적 export/CSR 환경에 적합).
+
+const DEFAULT_TTL_MS = 30_000;
+
+type CacheEntry<T> = { value: T; expiresAt: number };
+
+const store = new Map<string, CacheEntry<unknown>>();
+const inflight = new Map<string, Promise<unknown>>();
+
+export const cachedGet = <T>(
+  key: string,
+  loader: () => Promise<T>,
+  ttlMs: number = DEFAULT_TTL_MS,
+): Promise<T> => {
+  const now = Date.now();
+
+  const hit = store.get(key) as CacheEntry<T> | undefined;
+  if (hit && hit.expiresAt > now) {
+    return Promise.resolve(hit.value);
+  }
+
+  const pending = inflight.get(key) as Promise<T> | undefined;
+  if (pending) {
+    return pending;
+  }
+
+  const promise = loader()
+    .then((value) => {
+      store.set(key, { value, expiresAt: Date.now() + ttlMs });
+      return value;
+    })
+    .finally(() => {
+      inflight.delete(key);
+    });
+
+  inflight.set(key, promise);
+  return promise;
+};
+
+// 게시글 작성/수정 등으로 목록이 바뀐 뒤 강제 무효화가 필요할 때 사용.
+export const clearListCache = (): void => {
+  store.clear();
+  inflight.clear();
+};

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -6,6 +6,10 @@ export type BackendFetchOptions = RequestInit & {
   requiresAuth?: boolean;
 };
 
+// 공개 조회 응답에도 로그인 사용자면 개인화 필드(liked 등)가 섞여 내려온다.
+// 캐시 키에 붙여 로그인 상태/사용자 간 캐시 오염을 막는 데 쓴다.
+export const authScopeKey = (): string => auth.currentUser?.uid ?? "anon";
+
 export type BackendJsonOptions<RequestBody = unknown> = Omit<BackendFetchOptions, "body"> & {
   body?: BodyInit | null;
   json?: RequestBody;

--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -1,6 +1,7 @@
 // src/api/notice.ts
-import { backendJson } from "@/api/client";
+import { backendJson, backendFetch } from "@/api/client";
 
+// 인터페이스
 export interface Attachment {
   attachmentId: number;
   attachmentType: string;
@@ -44,7 +45,20 @@ interface NoticePageResponse {
   totalPages?: number;
 }
 
-// 공지사항 목록 조회 (클라이언트/서버 공용)
+export interface CreateNoticeRequest {
+  title: string;
+  content: string;
+  userId?: number;
+  description?: string;
+  visibility?: "PUBLIC" | "PRIVATE";
+  videoLink?: string | null;
+  githubLink?: string | null;
+  // 파일/이미지 처리
+  images?: number[];
+  files?: number[];
+}
+
+// 공지사항 목록 조회
 export async function getNotices(
   page: number = 1,
   size: number = 10,
@@ -66,7 +80,7 @@ export async function getNotices(
   };
 }
 
-// 클라이언트용 단건 상세 조회 함수
+// 클라이언트용 상세 조회 함수
 export async function getNoticeById(id: number): Promise<Notice | null> {
   const data = await backendJson<Notice>(`/api/posts/NOTICE/${id}`, {
     method: "GET",
@@ -75,4 +89,31 @@ export async function getNoticeById(id: number): Promise<Notice | null> {
   });
 
   return data;
+}
+
+// 공지사항 작성 함수
+export async function createNotice(
+  noticeData: CreateNoticeRequest,
+  files: File[] = [],
+): Promise<Notice> {
+  const formData = new FormData();
+
+  formData.append("request", new Blob([JSON.stringify(noticeData)], { type: "application/json" }));
+
+  files.forEach((file) => {
+    formData.append("files", file);
+  });
+
+  // fetch 호출
+  const response = await backendFetch("/api/posts/NOTICE", {
+    method: "POST",
+    body: formData,
+    requiresAuth: true,
+  });
+
+  if (!response.ok) {
+    throw new Error(`공지사항 등록 실패: ${response.status}`);
+  }
+
+  return response.json();
 }

--- a/src/api/notice.ts
+++ b/src/api/notice.ts
@@ -1,0 +1,78 @@
+// src/api/notice.ts
+import { backendJson } from "@/api/client";
+
+export interface Attachment {
+  attachmentId: number;
+  attachmentType: string;
+  originalFilename: string;
+  filePath: string;
+  fileType: string;
+  fileSize: number;
+  displayOrder: number;
+  image: boolean;
+}
+
+export interface Keyword {
+  keywordId: number;
+  keywordName: string;
+}
+
+export interface Notice {
+  postId: number;
+  userId: number;
+  boardType: string;
+  title: string;
+  content: string;
+  description: string | null;
+  videoLink: string | null;
+  githubLink: string | null;
+  visibility: string;
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+  thumbnailImage: string | null;
+  liked: boolean;
+  keywords: Keyword[];
+  images: Attachment[];
+  files: Attachment[];
+}
+
+interface NoticePageResponse {
+  content?: Notice[];
+  data?: Notice[];
+  totalPages?: number;
+}
+
+// 공지사항 목록 조회 (클라이언트/서버 공용)
+export async function getNotices(
+  page: number = 1,
+  size: number = 10,
+): Promise<{ notices: Notice[]; totalPages: number }> {
+  const backendPage = page - 1;
+
+  const data = await backendJson<NoticePageResponse>(
+    `/api/posts/NOTICE?page=${backendPage}&size=${size}&sortType=LATEST`,
+    {
+      method: "GET",
+      requiresAuth: false,
+      cache: "no-store",
+    },
+  );
+
+  return {
+    notices: data.content || data.data || [],
+    totalPages: data.totalPages || 1,
+  };
+}
+
+// 클라이언트용 단건 상세 조회 함수
+export async function getNoticeById(id: number): Promise<Notice | null> {
+  const data = await backendJson<Notice>(`/api/posts/NOTICE/${id}`, {
+    method: "GET",
+    requiresAuth: false,
+    cache: "no-store",
+  });
+
+  return data;
+}

--- a/src/api/posts/index.ts
+++ b/src/api/posts/index.ts
@@ -28,3 +28,11 @@ export {
   type PortfolioAttachmentType,
   type PortfolioDetail,
 } from "./portfolio-detail-api";
+export { getKeywords } from "./keyword-api";
+export {
+  createPortfolio,
+  type PortfolioCreateFiles,
+  type PortfolioCreateRequest,
+} from "./portfolio-create-api";
+export { updatePortfolio, type PortfolioUpdateRequest } from "./portfolio-update-api";
+export { deletePortfolio } from "./portfolio-delete-api";

--- a/src/api/posts/index.ts
+++ b/src/api/posts/index.ts
@@ -14,12 +14,21 @@ export {
   type SearchPortfoliosParams,
 } from "./portfolio-api";
 export {
+  createPost,
+  deletePost,
+  getPostDetail,
   getPosts,
+  updatePost,
   type BoardType,
+  type DeletePostResponse,
   type GetPostsParams,
   type Post,
+  type PostCreateRequest,
+  type PostDetail,
   type PostListResponse,
+  type PostMutationFiles,
   type PostSortType,
+  type PostUpdateRequest,
 } from "./posts-api";
 export { togglePostLike, type PostLikeToggleResponse } from "./post-like-api";
 export {

--- a/src/api/posts/keyword-api.ts
+++ b/src/api/posts/keyword-api.ts
@@ -1,0 +1,10 @@
+import { backendJson } from "@/api/client";
+import type { PortfolioKeyword } from "./portfolio-api";
+
+// 전체 키워드 조회. 작성 폼의 태그 선택 목록으로 사용한다.
+export const getKeywords = async (): Promise<PortfolioKeyword[]> => {
+  // 공개 조회: 비로그인도 접근 가능
+  return backendJson<PortfolioKeyword[]>("/api/keywords", {
+    requiresAuth: false,
+  });
+};

--- a/src/api/posts/portfolio-api.ts
+++ b/src/api/posts/portfolio-api.ts
@@ -1,4 +1,5 @@
-import { backendJson } from "@/api/client";
+import { authScopeKey, backendJson } from "@/api/client";
+import { cachedGet } from "@/api/cache";
 
 export type PortfolioBoardType = "PORTFOLIO" | "COMPANY_PROJECT" | "LAB_INTERN";
 export type PortfolioVisibility = "PUBLIC" | "PRIVATE";
@@ -81,10 +82,11 @@ const fetchSinglePortfolioPage = async (
   pageable: PortfolioPageable,
 ): Promise<PortfolioListPageResponse> => {
   const params = buildPortfolioPageableParams(pageable);
-  // 공개 조회: 비로그인도 접근 가능
-  return backendJson<PortfolioListPageResponse>(`/api/posts/${boardType}?${params.toString()}`, {
-    requiresAuth: false,
-  });
+  const path = `/api/posts/${boardType}?${params.toString()}`;
+  // 공개 조회: 비로그인도 접근 가능. liked 등 개인화 필드 때문에 auth scope로 캐시 분리
+  return cachedGet(`${authScopeKey()}|${path}`, () =>
+    backendJson<PortfolioListPageResponse>(path, { requiresAuth: false }),
+  );
 };
 
 const fetchSinglePortfolioSearch = async (
@@ -97,10 +99,11 @@ const fetchSinglePortfolioSearch = async (
   if (keyword) {
     params.set("keyword", keyword);
   }
-  // 공개 조회: 비로그인도 접근 가능
-  return backendJson<PortfolioListPageResponse>(`/api/posts/search?${params.toString()}`, {
-    requiresAuth: false,
-  });
+  const path = `/api/posts/search?${params.toString()}`;
+  // 공개 조회: 비로그인도 접근 가능. liked 등 개인화 필드 때문에 auth scope로 캐시 분리
+  return cachedGet(`${authScopeKey()}|${path}`, () =>
+    backendJson<PortfolioListPageResponse>(path, { requiresAuth: false }),
+  );
 };
 
 const mergePortfolioPages = (

--- a/src/api/posts/portfolio-api.ts
+++ b/src/api/posts/portfolio-api.ts
@@ -13,6 +13,7 @@ export type PortfolioKeyword = {
 export type PortfolioListItem = {
   postId: number;
   userId: number;
+  authorName: string;
   boardType: PortfolioBoardType;
   title: string;
   description: string;

--- a/src/api/posts/portfolio-create-api.ts
+++ b/src/api/posts/portfolio-create-api.ts
@@ -1,0 +1,42 @@
+import { backendJson } from "@/api/client";
+import type { PortfolioBoardType, PortfolioVisibility } from "./portfolio-api";
+import type { PortfolioDetail } from "./portfolio-detail-api";
+
+// POST /api/posts/{boardType} 의 JSON 파트(request)
+export type PortfolioCreateRequest = {
+  title: string;
+  description?: string;
+  content?: string;
+  videoLink?: string;
+  githubLink?: string;
+  visibility?: PortfolioVisibility;
+  keywordIds?: number[];
+};
+
+// multipart 파일 파트
+export type PortfolioCreateFiles = {
+  thumbnail?: File | null;
+  images?: File[];
+  files?: File[];
+};
+
+export const createPortfolio = async (
+  boardType: PortfolioBoardType,
+  request: PortfolioCreateRequest,
+  { thumbnail, images = [], files = [] }: PortfolioCreateFiles = {},
+): Promise<PortfolioDetail> => {
+  const formData = new FormData();
+  // Spring @RequestPart("request"): JSON을 application/json Blob 파트로 전송
+  formData.append("request", new Blob([JSON.stringify(request)], { type: "application/json" }));
+  if (thumbnail) {
+    formData.append("thumbnail", thumbnail);
+  }
+  images.forEach((image) => formData.append("images", image));
+  files.forEach((file) => formData.append("files", file));
+
+  // 작성은 로그인 필요(requiresAuth 기본값 true). FormData는 client가 Content-Type을 자동 처리한다.
+  return backendJson<PortfolioDetail>(`/api/posts/${boardType}`, {
+    method: "POST",
+    body: formData,
+  });
+};

--- a/src/api/posts/portfolio-delete-api.ts
+++ b/src/api/posts/portfolio-delete-api.ts
@@ -1,0 +1,10 @@
+import { backendJson } from "@/api/client";
+import type { PortfolioBoardType } from "./portfolio-api";
+
+// DELETE /api/posts/{boardType}/{postId} — 게시글 삭제 (로그인 필요)
+export const deletePortfolio = async (
+  boardType: PortfolioBoardType,
+  postId: number,
+): Promise<void> => {
+  await backendJson(`/api/posts/${boardType}/${postId}`, { method: "DELETE" });
+};

--- a/src/api/posts/portfolio-update-api.ts
+++ b/src/api/posts/portfolio-update-api.ts
@@ -1,0 +1,36 @@
+import { backendJson } from "@/api/client";
+import type { PortfolioBoardType, PortfolioVisibility } from "./portfolio-api";
+import type { PortfolioCreateFiles } from "./portfolio-create-api";
+import type { PortfolioDetail } from "./portfolio-detail-api";
+
+// PUT /api/posts/{boardType}/{postId} 의 JSON 파트(request)
+export type PortfolioUpdateRequest = {
+  title?: string;
+  description?: string;
+  content?: string;
+  videoLink?: string;
+  githubLink?: string;
+  visibility?: PortfolioVisibility;
+  keywordIds?: number[];
+  deleteAttachmentIds?: number[];
+};
+
+export const updatePortfolio = async (
+  boardType: PortfolioBoardType,
+  postId: number,
+  request: PortfolioUpdateRequest,
+  { thumbnail, images = [], files = [] }: PortfolioCreateFiles = {},
+): Promise<PortfolioDetail> => {
+  const formData = new FormData();
+  formData.append("request", new Blob([JSON.stringify(request)], { type: "application/json" }));
+  if (thumbnail) {
+    formData.append("thumbnail", thumbnail);
+  }
+  images.forEach((image) => formData.append("images", image));
+  files.forEach((file) => formData.append("files", file));
+
+  return backendJson<PortfolioDetail>(`/api/posts/${boardType}/${postId}`, {
+    method: "PUT",
+    body: formData,
+  });
+};

--- a/src/api/posts/posts-api.ts
+++ b/src/api/posts/posts-api.ts
@@ -1,4 +1,5 @@
-import { backendJson } from "@/api/client";
+import { authScopeKey, backendJson } from "@/api/client";
+import { cachedGet } from "@/api/cache";
 import {
   buildPortfolioPageableParams,
   getPortfolioList,
@@ -124,8 +125,8 @@ export const getPosts = async (
     ? `/api/posts/search?boardType=${boardType}${query ? `&${query}` : ""}`
     : `/api/posts/${boardType}${query ? `?${query}` : ""}`;
 
-  const res = await backendJson<RawPostListResponse>(path, {
-    requiresAuth: false,
-  });
+  const res = await cachedGet(`${authScopeKey()}|${path}`, () =>
+    backendJson<RawPostListResponse>(path, { requiresAuth: false }),
+  );
   return normalizePosts(res);
 };

--- a/src/api/posts/posts-api.ts
+++ b/src/api/posts/posts-api.ts
@@ -9,6 +9,7 @@ import {
   type PortfolioKeyword,
   type PortfolioListItem,
 } from "./portfolio-api";
+import type { PortfolioAttachment } from "./portfolio-detail-api";
 
 export type BoardType =
   | "PORTFOLIO"
@@ -22,6 +23,7 @@ export type PostSortType = "LATEST" | "POPULAR" | "VIEWS";
 export type Post = {
   postId: number;
   userId: number;
+  authorName?: string;
   boardType: BoardType;
   title: string;
   description: string;
@@ -129,4 +131,103 @@ export const getPosts = async (
     backendJson<RawPostListResponse>(path, { requiresAuth: false }),
   );
   return normalizePosts(res);
+};
+
+export type PostDetail = {
+  postId: number;
+  userId: number;
+  authorName?: string;
+  boardType: BoardType;
+  title: string;
+  content: string;
+  description: string;
+  videoLink: string | null;
+  githubLink: string | null;
+  visibility: "PUBLIC" | "PRIVATE";
+  viewCount: number;
+  likeCount: number;
+  commentCount: number;
+  createdAt: string;
+  thumbnailImage: string | null;
+  liked: boolean | null;
+  keywords: PortfolioKeyword[];
+  images: PortfolioAttachment[];
+  files: PortfolioAttachment[];
+};
+
+export type PostCreateRequest = {
+  title: string;
+  description?: string;
+  content?: string;
+  videoLink?: string;
+  githubLink?: string;
+  visibility?: "PUBLIC" | "PRIVATE";
+  keywordIds?: number[];
+};
+
+export type PostUpdateRequest = PostCreateRequest & {
+  deleteAttachmentIds?: number[];
+};
+
+export type PostMutationFiles = {
+  thumbnail?: File | null;
+  images?: File[];
+  files?: File[];
+};
+
+export type DeletePostResponse = {
+  postId: number;
+};
+
+// Spring이 request 파트를 application/json으로 파싱하므로 문자열이 아닌 Blob으로 감싼다.
+// (문자열로 append하면 text/plain으로 전송되어 415 응답)
+const buildPostFormData = (
+  request: PostCreateRequest | PostUpdateRequest,
+  files?: PostMutationFiles,
+): FormData => {
+  const formData = new FormData();
+  formData.append("request", new Blob([JSON.stringify(request)], { type: "application/json" }));
+  if (files?.thumbnail) formData.append("thumbnail", files.thumbnail);
+  files?.images?.forEach((image) => formData.append("images", image));
+  files?.files?.forEach((file) => formData.append("files", file));
+  return formData;
+};
+
+export const getPostDetail = async (boardType: BoardType, postId: number): Promise<PostDetail> => {
+  // 공개 조회: 비로그인도 접근 가능 (로그인 시 liked 등 개인화 정보 포함)
+  return backendJson<PostDetail>(`/api/posts/${boardType}/${postId}`, {
+    requiresAuth: false,
+  });
+};
+
+export const createPost = async (
+  boardType: BoardType,
+  request: PostCreateRequest,
+  files?: PostMutationFiles,
+): Promise<PostDetail> => {
+  return backendJson<PostDetail>(`/api/posts/${boardType}`, {
+    method: "POST",
+    body: buildPostFormData(request, files),
+  });
+};
+
+export const updatePost = async (
+  boardType: BoardType,
+  postId: number,
+  request: PostUpdateRequest,
+  files?: PostMutationFiles,
+): Promise<PostDetail> => {
+  return backendJson<PostDetail>(`/api/posts/${boardType}/${postId}`, {
+    method: "PUT",
+    body: buildPostFormData(request, files),
+  });
+};
+
+export const deletePost = async (
+  boardType: BoardType,
+  postId: number,
+): Promise<DeletePostResponse> => {
+  return backendJson<DeletePostResponse>(`/api/posts/${boardType}/${postId}`, {
+    method: "DELETE",
+  });
 };

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { signOut, useAuthUser } from "@/lib/auth";
+import { Navigation, Footer } from "@/shared/ui";
+import { AdminSidebar } from "@/screens/admin";
+import type { NavItem } from "@/shared/ui";
+
+const navItems: NavItem[] = [
+  { label: "포트폴리오", href: "/portfolio" },
+  { label: "소개", href: "#about" },
+  { label: "공지사항", href: "#notice" },
+];
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const router = useRouter();
+  const authUser = useAuthUser();
+
+  const handleLogout = async () => {
+    await signOut();
+    router.replace("/login");
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-gray-50">
+      <Navigation
+        items={navItems}
+        user={authUser ?? undefined}
+        onLogin={() => router.push("/login")}
+        onSignup={() => router.push("/login")}
+        onLogout={() => void handleLogout()}
+      />
+      <div className="mx-auto flex min-h-[calc(100vh-80px)] w-full max-w-360 border-x border-neutral-200 bg-neutral-50">
+        <AdminSidebar />
+        <main className="flex flex-1 overflow-auto">{children}</main>
+      </div>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/admin/notices/edit/page.tsx
+++ b/src/app/admin/notices/edit/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import { AdminNoticesEditRoute } from "@/screens/admin";
+
+export default function AdminNoticesEditRoutePage(): React.ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <AdminNoticesEditRoute />
+    </Suspense>
+  );
+}

--- a/src/app/admin/notices/page.tsx
+++ b/src/app/admin/notices/page.tsx
@@ -1,0 +1,5 @@
+import { AdminNoticesPage } from "@/screens/admin";
+
+export default function AdminNoticesRoute() {
+  return <AdminNoticesPage />;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+export default function AdminRoute(): null {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace("/admin/notices");
+  }, [router]);
+
+  return null;
+}

--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -24,6 +24,7 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
   const { session, isAuthReady } = useAuthSession();
   const shouldRenderNavigation =
     !headerlessRoutes.has(pathname) &&
+    !pathname.startsWith("/admin") &&
     !routeOwnedNavigationPrefixes.some(
       (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
     );

--- a/src/app/notice/create/page.tsx
+++ b/src/app/notice/create/page.tsx
@@ -1,0 +1,7 @@
+// src/app/notice/create/page.tsx
+import { NoticeCreateScreen } from "@/screens/notice-create";
+
+export default function NoticeCreateRoute() {
+  // 나중에 사용자 권한 검사(관리자인지 확인) 로직이 이곳에 추가될 수 있습니다.
+  return <NoticeCreateScreen />;
+}

--- a/src/app/notice/detail/page.tsx
+++ b/src/app/notice/detail/page.tsx
@@ -4,16 +4,13 @@
 import { Suspense, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
 import { NoticeDetailScreen } from "@/screens/notice-detail";
-// 💡 서버용 API(getServerNoticeById) 대신 클라이언트용 API(getNoticeById)를 사용합니다.
 import { getNoticeById, type Notice } from "@/api/notice";
-// 💡 경로에 맞게 EmptyState 컴포넌트를 불러와주세요
 import { EmptyState } from "@/shared/ui/empty-states/empty-states";
 
 function NoticeDetailWrapper() {
   const searchParams = useSearchParams();
   const router = useRouter();
 
-  // URL에서 ?id= 값을 가져옵니다.
   const idParam = searchParams.get("id");
   const noticeId = idParam ? Number(idParam) : null;
 
@@ -44,7 +41,7 @@ function NoticeDetailWrapper() {
     fetchDetail();
   }, [noticeId]);
 
-  // 1. 로딩 중 화면
+  // 로딩 중 화면
   if (isLoading) {
     return (
       <div className="flex min-h-[500px] w-full items-center justify-center pt-[160px]">
@@ -53,7 +50,7 @@ function NoticeDetailWrapper() {
     );
   }
 
-  // 2. 에러가 났거나, id가 없거나, 데이터가 없을 때의 예외 처리
+  // 예외 처리
   if (error || !notice || !noticeId) {
     return (
       <div className="pt-[160px] pb-[80px]">
@@ -70,13 +67,11 @@ function NoticeDetailWrapper() {
     );
   }
 
-  // 3. 정상 렌더링
   return <NoticeDetailScreen notice={notice} />;
 }
 
 export default function NoticeDetailRoute() {
   return (
-    // useSearchParams를 사용하는 컴포넌트는 반드시 Suspense로 감싸주어야 빌드 에러가 나지 않습니다.
     <Suspense fallback={<div>Loading...</div>}>
       <NoticeDetailWrapper />
     </Suspense>

--- a/src/app/notice/detail/page.tsx
+++ b/src/app/notice/detail/page.tsx
@@ -1,0 +1,84 @@
+// src/app/notice/detail/page.tsx
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { NoticeDetailScreen } from "@/screens/notice-detail";
+// 💡 서버용 API(getServerNoticeById) 대신 클라이언트용 API(getNoticeById)를 사용합니다.
+import { getNoticeById, type Notice } from "@/api/notice";
+// 💡 경로에 맞게 EmptyState 컴포넌트를 불러와주세요
+import { EmptyState } from "@/shared/ui/empty-states/empty-states";
+
+function NoticeDetailWrapper() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+
+  // URL에서 ?id= 값을 가져옵니다.
+  const idParam = searchParams.get("id");
+  const noticeId = idParam ? Number(idParam) : null;
+
+  const [notice, setNotice] = useState<Notice | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!noticeId) {
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchDetail = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getNoticeById(noticeId);
+        setNotice(data);
+      } catch (err) {
+        console.error("공지사항 상세 로딩 실패:", err);
+        setError(err instanceof Error ? err : new Error("데이터를 불러오지 못했습니다."));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchDetail();
+  }, [noticeId]);
+
+  // 1. 로딩 중 화면
+  if (isLoading) {
+    return (
+      <div className="flex min-h-[500px] w-full items-center justify-center pt-[160px]">
+        <span className="text-[15px] text-gray-500">공지사항을 불러오는 중입니다...</span>
+      </div>
+    );
+  }
+
+  // 2. 에러가 났거나, id가 없거나, 데이터가 없을 때의 예외 처리
+  if (error || !notice || !noticeId) {
+    return (
+      <div className="pt-[160px] pb-[80px]">
+        <EmptyState
+          variant="no-results"
+          title="공지사항을 찾을 수 없습니다"
+          description="존재하지 않거나 삭제된 공지사항입니다."
+          primaryAction={{
+            label: "목록으로 돌아가기",
+            onClick: () => router.push("/notice"),
+          }}
+        />
+      </div>
+    );
+  }
+
+  // 3. 정상 렌더링
+  return <NoticeDetailScreen notice={notice} />;
+}
+
+export default function NoticeDetailRoute() {
+  return (
+    // useSearchParams를 사용하는 컴포넌트는 반드시 Suspense로 감싸주어야 빌드 에러가 나지 않습니다.
+    <Suspense fallback={<div>Loading...</div>}>
+      <NoticeDetailWrapper />
+    </Suspense>
+  );
+}

--- a/src/app/notice/page.tsx
+++ b/src/app/notice/page.tsx
@@ -1,0 +1,87 @@
+// src/app/notice/page.tsx
+"use client";
+
+import { Suspense, useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { NoticeScreen } from "@/screens/notice";
+import { getNotices, type Notice } from "@/api/notice";
+
+import { EmptyState } from "@/shared/ui/empty-states/empty-states";
+
+function NoticeListWrapper() {
+  const searchParams = useSearchParams();
+  const pageParam = searchParams.get("page");
+  const currentPage = Number(pageParam) || 1;
+
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    const fetchNotices = async () => {
+      setIsLoading(true);
+      setError(null);
+      try {
+        const data = await getNotices(currentPage);
+        setNotices(data.notices);
+        setTotalPages(data.totalPages);
+      } catch (err) {
+        console.error("공지사항 로딩 실패:", err);
+        setError(err instanceof Error ? err : new Error("알 수 없는 오류가 발생했습니다."));
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchNotices();
+  }, [currentPage]);
+
+  if (error) {
+    return (
+      <div className="pt-[160px] pb-[80px]">
+        <EmptyState
+          variant="error"
+          title="데이터를 불러오지 못했습니다"
+          description={`문제가 지속되면 관리자에게 문의해 주세요.`}
+          primaryAction={{
+            label: "다시 시도하기",
+            onClick: () => window.location.reload(),
+          }}
+        />
+      </div>
+    );
+  }
+
+  // 로딩 중
+  if (isLoading) {
+    return (
+      <div className="mx-auto flex min-h-[500px] w-full max-w-[1440px] items-center justify-center pt-[160px]">
+        <span className="text-[15px] text-gray-500">목록을 불러오는 중입니다...</span>
+      </div>
+    );
+  }
+
+  // 실제 데이터가 0건일 때
+  if (notices.length === 0) {
+    return (
+      <div className="pt-[160px] pb-[80px]">
+        <EmptyState
+          variant="no-content"
+          title="아직 등록된 공지사항이 없습니다"
+          description="새로운 공지사항이 올라오면 이곳에서 확인하실 수 있습니다."
+        />
+      </div>
+    );
+  }
+
+  return <NoticeScreen notices={notices} currentPage={currentPage} totalPages={totalPages} />;
+}
+
+export default function NoticeRoute() {
+  return (
+    <Suspense fallback={<div>Loading...</div>}>
+      <NoticeListWrapper />
+    </Suspense>
+  );
+}

--- a/src/app/portfolio/create/page.tsx
+++ b/src/app/portfolio/create/page.tsx
@@ -1,0 +1,5 @@
+import { PortfolioCreatePage } from "@/screens/portfolio-create";
+
+export default function PortfolioCreateRoute(): React.ReactElement {
+  return <PortfolioCreatePage />;
+}

--- a/src/app/portfolio/edit/page.tsx
+++ b/src/app/portfolio/edit/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import { PortfolioEditRoute } from "@/screens/portfolio-edit";
+
+export default function PortfolioEditRoutePage(): React.ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <PortfolioEditRoute />
+    </Suspense>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -277,4 +277,82 @@ body {
   .animate-shimmer {
     animation: shimmer 1.5s infinite;
   }
+
+  /* 로딩 점 물결 바운스 (Loading 컴포넌트) */
+  @keyframes wave-bounce {
+    0%, 60%, 100% { transform: translateY(0); }
+    30% { transform: translateY(-60%); }
+  }
+  .animate-wave-bounce {
+    animation: wave-bounce 1.2s ease-in-out infinite;
+  }
+
+  /* 전체 화면 로딩 배경 판: 화면을 통째로 덮는 솔리드.
+     윗변은 SVG 2차 베지어(Q)로 그려, 가운데 컨트롤 포인트의 Y만 움직여 곡률을 만든다.
+     (border-radius 로 둥글리는 게 아니라, 직선 가운데를 실로 당기듯 위로 볼록하게 하는 방식)
+
+     lift: 윗변이 화면 위로 빠져나간 뒤에 감속(ease-in 꼬리)이 끝나도록 주는 여유 높이. */
+  .loading-panel {
+    --loading-panel-lift: 12vh;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: calc(100% + var(--loading-panel-lift));
+  }
+  /* preserveAspectRatio="none" + overflow visible → 곡선이 뷰박스 위로 볼록해져도 잘리지 않고 늘어난다 */
+  .loading-panel-svg {
+    display: block;
+    width: 100%;
+    height: 100%;
+    overflow: visible;
+  }
+  /* Firefox 등 CSS `d` 애니메이션 미지원 브라우저는 이 곡선 d(리딩 아치)로 고정 표시. */
+  .loading-panel-fill {
+    d: path("M 0 0 Q 50 -22 100 0 L 100 100 L 0 100 Z");
+  }
+
+  /* 전체 화면 로딩 진입 (Loading 컴포넌트 isFullScreen)
+     솔리드가 아래에서 한 번 올라와 이전 화면을 덮고 그대로 머무른다(반복 없음).
+
+     핵심: 상승(translateY)과 곡률(d)에 '같은 duration·같은 timing-function'을 줘서
+     매 순간 곡률 진행률 = 상승 진행률이 되도록 동기화한다.
+     → 느리게 출발할 땐 거의 직선, 속도가 붙을수록 아치가 함께 자란다(툭 튀지 않음).
+     정착 시 아치 코너(y=0)는 lift 만큼 화면 위로 빠져나가 화면은 평평하게 덮인다. */
+  @keyframes panel-cover {
+    from { transform: translateY(100%); }
+    to   { transform: translateY(0); }
+  }
+  @keyframes panel-curve {
+    from { d: path("M 0 0 Q 50 0 100 0 L 100 100 L 0 100 Z"); }
+    to   { d: path("M 0 0 Q 50 -22 100 0 L 100 100 L 0 100 Z"); }
+  }
+  .animate-panel-cover {
+    /* ease-in (가속): 처음엔 천천히 밀려 올라오다 끝으로 갈수록 훅 빨라지며 덮는다 (텐션 유지, 속도만 ↑) */
+    animation: panel-cover 0.6s cubic-bezier(0.55, 0, 0.85, 0.3) forwards;
+  }
+  .animate-panel-cover .loading-panel-fill {
+    /* 상승과 완전히 동일한 타이밍 — 곡률이 이동량에 1:1로 붙어 따로 놀지 않는다 */
+    animation: panel-curve 0.6s cubic-bezier(0.55, 0, 0.85, 0.3) forwards;
+  }
+
+  /* 문구·점은 아치가 화면을 덮은 뒤에 떠오른다 (backwards: 지연 동안 숨김) */
+  @keyframes loading-content-in {
+    from { opacity: 0; transform: translateY(8px); }
+    to   { opacity: 1; transform: translateY(0); }
+  }
+  .animate-loading-content-in {
+    /* 아치가 화면을 덮은 직후(≈0.55s) 문구·점이 떠오르도록 지연을 상승 속도에 맞춰 당김 */
+    animation: loading-content-in 0.3s ease-out 0.5s backwards;
+  }
+
+  /* 모션 민감 사용자 배려: 로딩 모션 정지 (판은 덮은 상태, 콘텐츠는 보이는 상태로 고정) */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-wave-bounce,
+    .animate-panel-cover,
+    .animate-panel-cover .loading-panel-fill,
+    .animate-loading-content-in {
+      animation: none;
+    }
+  }
 }

--- a/src/lib/auth/auth-session.ts
+++ b/src/lib/auth/auth-session.ts
@@ -18,6 +18,8 @@ export type StoredSession = {
   name: string | null;
   role: BackendUser["role"];
   adminRole: BackendUser["adminRole"];
+  // 백엔드 사용자 식별자(소유권 판정 등에 사용). 구버전 세션에는 없을 수 있어 nullable.
+  userId: number | null;
 };
 
 const AUTH_SESSION_STORAGE_KEY = "aim-auth-session";
@@ -54,6 +56,7 @@ const normalizeStoredSession = (value: unknown): StoredSession | null => {
       adminRole: adminRoles.has(s.adminRole as BackendUser["adminRole"])
         ? (s.adminRole as BackendUser["adminRole"])
         : "NONE",
+      userId: typeof s.userId === "number" ? s.userId : null,
     };
   }
 
@@ -91,6 +94,7 @@ export const saveAuthSession = (session: AuthSession): void => {
     name: toDisplayName(session.backendUser.name) ?? toDisplayName(session.displayName),
     role: session.backendUser.role,
     adminRole: session.backendUser.adminRole ?? "NONE",
+    userId: session.backendUser.userId ?? null,
   };
 
   window.localStorage.setItem(AUTH_SESSION_STORAGE_KEY, JSON.stringify(toStore));

--- a/src/lib/posts/index.ts
+++ b/src/lib/posts/index.ts
@@ -1,1 +1,5 @@
 export { useTogglePostLike, type UseTogglePostLikeResult } from "./use-toggle-post-like";
+export { useKeywords, type UseKeywordsResult } from "./use-keywords";
+export { useCreatePortfolio, type UseCreatePortfolioResult } from "./use-create-portfolio";
+export { useUpdatePortfolio, type UseUpdatePortfolioResult } from "./use-update-portfolio";
+export { useDeletePortfolio, type UseDeletePortfolioResult } from "./use-delete-portfolio";

--- a/src/lib/posts/use-create-portfolio.ts
+++ b/src/lib/posts/use-create-portfolio.ts
@@ -1,0 +1,54 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  createPortfolio,
+  type PortfolioBoardType,
+  type PortfolioCreateFiles,
+  type PortfolioCreateRequest,
+  type PortfolioDetail,
+} from "@/api/posts";
+
+export type UseCreatePortfolioResult = {
+  submit: (
+    boardType: PortfolioBoardType,
+    request: PortfolioCreateRequest,
+    files: PortfolioCreateFiles,
+  ) => Promise<PortfolioDetail | null>;
+  isSubmitting: boolean;
+  error: Error | null;
+};
+
+const toErrorInstance = (cause: unknown): Error => {
+  if (cause instanceof Error) return cause;
+  if (typeof cause === "string") return new Error(cause);
+  return new Error("포트폴리오 저장에 실패했습니다.");
+};
+
+export const useCreatePortfolio = (): UseCreatePortfolioResult => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const submit = useCallback(
+    async (
+      boardType: PortfolioBoardType,
+      request: PortfolioCreateRequest,
+      files: PortfolioCreateFiles,
+    ) => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        return await createPortfolio(boardType, request, files);
+      } catch (cause) {
+        console.error("포트폴리오 저장에 실패했습니다.", cause);
+        setError(toErrorInstance(cause));
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  return { submit, isSubmitting, error };
+};

--- a/src/lib/posts/use-delete-portfolio.ts
+++ b/src/lib/posts/use-delete-portfolio.ts
@@ -1,0 +1,38 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { deletePortfolio, type PortfolioBoardType } from "@/api/posts";
+
+export type UseDeletePortfolioResult = {
+  remove: (boardType: PortfolioBoardType, postId: number) => Promise<boolean>;
+  isDeleting: boolean;
+  error: Error | null;
+};
+
+const toErrorInstance = (cause: unknown): Error => {
+  if (cause instanceof Error) return cause;
+  if (typeof cause === "string") return new Error(cause);
+  return new Error("포트폴리오 삭제에 실패했습니다.");
+};
+
+export const useDeletePortfolio = (): UseDeletePortfolioResult => {
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const remove = useCallback(async (boardType: PortfolioBoardType, postId: number) => {
+    setIsDeleting(true);
+    setError(null);
+    try {
+      await deletePortfolio(boardType, postId);
+      return true;
+    } catch (cause) {
+      console.error("포트폴리오 삭제에 실패했습니다.", cause);
+      setError(toErrorInstance(cause));
+      return false;
+    } finally {
+      setIsDeleting(false);
+    }
+  }, []);
+
+  return { remove, isDeleting, error };
+};

--- a/src/lib/posts/use-keywords.ts
+++ b/src/lib/posts/use-keywords.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getKeywords, type PortfolioKeyword } from "@/api/posts";
+
+export type UseKeywordsResult = {
+  keywords: PortfolioKeyword[];
+  isLoading: boolean;
+  error: Error | null;
+};
+
+const toErrorInstance = (cause: unknown): Error => {
+  if (cause instanceof Error) return cause;
+  if (typeof cause === "string") return new Error(cause);
+  return new Error("키워드를 불러오지 못했습니다.");
+};
+
+export const useKeywords = (): UseKeywordsResult => {
+  const [keywords, setKeywords] = useState<PortfolioKeyword[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    let isCancelled = false;
+
+    getKeywords()
+      .then((response) => {
+        if (isCancelled) return;
+        setKeywords(response);
+      })
+      .catch((cause: unknown) => {
+        if (isCancelled) return;
+        setError(toErrorInstance(cause));
+      })
+      .finally(() => {
+        if (isCancelled) return;
+        setIsLoading(false);
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, []);
+
+  return { keywords, isLoading, error };
+};

--- a/src/lib/posts/use-update-portfolio.ts
+++ b/src/lib/posts/use-update-portfolio.ts
@@ -1,0 +1,56 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import {
+  updatePortfolio,
+  type PortfolioBoardType,
+  type PortfolioCreateFiles,
+  type PortfolioDetail,
+  type PortfolioUpdateRequest,
+} from "@/api/posts";
+
+export type UseUpdatePortfolioResult = {
+  submit: (
+    boardType: PortfolioBoardType,
+    postId: number,
+    request: PortfolioUpdateRequest,
+    files: PortfolioCreateFiles,
+  ) => Promise<PortfolioDetail | null>;
+  isSubmitting: boolean;
+  error: Error | null;
+};
+
+const toErrorInstance = (cause: unknown): Error => {
+  if (cause instanceof Error) return cause;
+  if (typeof cause === "string") return new Error(cause);
+  return new Error("포트폴리오 수정에 실패했습니다.");
+};
+
+export const useUpdatePortfolio = (): UseUpdatePortfolioResult => {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const submit = useCallback(
+    async (
+      boardType: PortfolioBoardType,
+      postId: number,
+      request: PortfolioUpdateRequest,
+      files: PortfolioCreateFiles,
+    ) => {
+      setIsSubmitting(true);
+      setError(null);
+      try {
+        return await updatePortfolio(boardType, postId, request, files);
+      } catch (cause) {
+        console.error("포트폴리오 수정에 실패했습니다.", cause);
+        setError(toErrorInstance(cause));
+        return null;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [],
+  );
+
+  return { submit, isSubmitting, error };
+};

--- a/src/lib/user/index.ts
+++ b/src/lib/user/index.ts
@@ -1,0 +1,1 @@
+export { useCurrentUserId, type UseCurrentUserIdResult } from "./use-current-user-id";

--- a/src/lib/user/use-current-user-id.ts
+++ b/src/lib/user/use-current-user-id.ts
@@ -1,0 +1,17 @@
+"use client";
+
+import { useAuthSession } from "@/lib/auth";
+
+export type UseCurrentUserIdResult = {
+  userId: number | null;
+  // 인증 상태(및 세션) 확정 여부. 소유권 판정 시점 결정에 사용한다.
+  isResolved: boolean;
+};
+
+// 로그인 시 저장된 백엔드 userId를 세션에서 읽어 반환한다.
+// 응답이 불안정한 /api/users/me 대신 로그인 응답(LoginResponse.userId)을 사용한다.
+export const useCurrentUserId = (): UseCurrentUserIdResult => {
+  const { session, isAuthReady } = useAuthSession();
+
+  return { userId: session?.userId ?? null, isResolved: isAuthReady };
+};

--- a/src/screens/admin/admin-sidebar.tsx
+++ b/src/screens/admin/admin-sidebar.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+type SidebarItem = {
+  label: string;
+  href: string;
+  icon: React.ReactNode;
+};
+
+const BellIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M18 8A6 6 0 0 0 6 8c0 7-3 9-3 9h18s-3-2-3-9" />
+    <path d="M13.73 21a2 2 0 0 1-3.46 0" />
+  </svg>
+);
+
+const SIDEBAR_ITEMS: SidebarItem[] = [
+  { label: "공지사항 관리", href: "/admin/notices", icon: <BellIcon /> },
+];
+
+export const AdminSidebar = () => {
+  const pathname = usePathname();
+
+  return (
+    <aside className="w-64 shrink-0 border-r border-neutral-200 bg-neutral-50 p-6">
+      <p className="mb-4 text-lg font-semibold leading-tight tracking-normal text-[#111]">
+        관리자 콘솔
+      </p>
+      <p className="mb-3 text-[11px] font-medium uppercase tracking-wider text-neutral-400">
+        관리자 관리
+      </p>
+      <nav className="flex flex-col gap-1">
+        {SIDEBAR_ITEMS.map((item) => {
+          const isActive = pathname.startsWith(item.href);
+
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={[
+                "flex items-center gap-2.5 rounded-lg px-3 py-2 text-sm font-medium leading-normal transition-colors",
+                isActive
+                  ? "bg-[#004a9c] text-white"
+                  : "text-neutral-600 hover:bg-(--color-primary-50) hover:text-[#004a9c]",
+              ].join(" ")}
+            >
+              {item.icon}
+              {item.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </aside>
+  );
+};

--- a/src/screens/admin/index.ts
+++ b/src/screens/admin/index.ts
@@ -1,0 +1,2 @@
+export { AdminSidebar } from "./admin-sidebar";
+export { AdminNoticesPage, AdminNoticesEditPage, AdminNoticesEditRoute } from "./notices";

--- a/src/screens/admin/notices/index.ts
+++ b/src/screens/admin/notices/index.ts
@@ -1,0 +1,3 @@
+export { AdminNoticesPage } from "./notices";
+export { AdminNoticesEditPage } from "./notices-edit";
+export { AdminNoticesEditRoute } from "./notices-edit-route";

--- a/src/screens/admin/notices/notices-edit-route.tsx
+++ b/src/screens/admin/notices/notices-edit-route.tsx
@@ -1,0 +1,20 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { AdminNoticesEditPage } from "./notices-edit";
+
+export const AdminNoticesEditRoute = (): React.ReactElement => {
+  const searchParams = useSearchParams();
+  const id = searchParams.get("id");
+  const isValidId = id !== null && (id === "new" || /^\d+$/.test(id));
+
+  if (!isValidId) {
+    return (
+      <div className="flex-1 bg-white p-8">
+        <p className="py-16 text-center text-[14px] text-[#999]">잘못된 접근입니다.</p>
+      </div>
+    );
+  }
+
+  return <AdminNoticesEditPage id={id} />;
+};

--- a/src/screens/admin/notices/notices-edit.tsx
+++ b/src/screens/admin/notices/notices-edit.tsx
@@ -1,0 +1,335 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { clearListCache } from "@/api/cache";
+import { createPost, deletePost, getPostDetail, updatePost } from "@/api/posts";
+import type { PortfolioAttachment } from "@/api/posts";
+
+const BackIcon = () => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <polyline points="15 18 9 12 15 6" />
+  </svg>
+);
+
+const FileIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+    <polyline points="14 2 14 8 20 8" />
+  </svg>
+);
+
+const XIcon = () => (
+  <svg
+    width="12"
+    height="12"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2.5"
+    strokeLinecap="round"
+  >
+    <line x1="18" y1="6" x2="6" y2="18" />
+    <line x1="6" y1="6" x2="18" y2="18" />
+  </svg>
+);
+
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
+type Props = { id: string };
+
+export const AdminNoticesEditPage = ({ id }: Props) => {
+  const router = useRouter();
+  const isCreateMode = id === "new";
+  const postId = isCreateMode ? null : Number(id);
+
+  const [title, setTitle] = useState("");
+  const [content, setContent] = useState("");
+  const [authorName, setAuthorName] = useState("관리자");
+  const [existingFiles, setExistingFiles] = useState<PortfolioAttachment[]>([]);
+  const [deleteAttachmentIds, setDeleteAttachmentIds] = useState<number[]>([]);
+  const [newFiles, setNewFiles] = useState<File[]>([]);
+  const [isLoading, setIsLoading] = useState(!isCreateMode);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (postId === null || Number.isNaN(postId)) return;
+
+    let isMounted = true;
+
+    const fetchDetail = async () => {
+      try {
+        const detail = await getPostDetail("NOTICE", postId);
+        if (!isMounted) return;
+        setTitle(detail.title);
+        setContent(detail.content ?? "");
+        if (detail.authorName) setAuthorName(detail.authorName);
+        setExistingFiles([...detail.files, ...detail.images]);
+      } catch (fetchError) {
+        console.error("[admin] 공지사항 상세 조회 실패", fetchError);
+        if (isMounted) setError("공지사항을 불러오지 못했습니다.");
+      } finally {
+        if (isMounted) setIsLoading(false);
+      }
+    };
+
+    void fetchDetail();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [postId]);
+
+  const removeExistingFile = (attachmentId: number) => {
+    setExistingFiles((files) => files.filter((file) => file.attachmentId !== attachmentId));
+    setDeleteAttachmentIds((ids) => [...ids, attachmentId]);
+  };
+
+  const handleNewFilesChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selected = Array.from(event.target.files ?? []);
+    if (selected.length > 0) setNewFiles((files) => [...files, ...selected]);
+    event.target.value = "";
+  };
+
+  const removeNewFile = (index: number) => {
+    setNewFiles((files) => files.filter((_, i) => i !== index));
+  };
+
+  const handleSubmit = async () => {
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      setError("제목을 입력해주세요.");
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      const request = { title: trimmedTitle, content, visibility: "PUBLIC" as const };
+      if (isCreateMode) {
+        await createPost("NOTICE", request, { files: newFiles });
+      } else if (postId !== null) {
+        await updatePost(
+          "NOTICE",
+          postId,
+          { ...request, deleteAttachmentIds },
+          { files: newFiles },
+        );
+      }
+      clearListCache();
+      router.push("/admin/notices");
+    } catch (submitError) {
+      console.error("[admin] 공지사항 저장 실패", submitError);
+      setError("요청 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (postId === null) return;
+    if (!window.confirm("공지사항을 삭제하시겠습니까?")) return;
+
+    setError(null);
+    setIsSubmitting(true);
+
+    try {
+      await deletePost("NOTICE", postId);
+      clearListCache();
+      router.push("/admin/notices");
+    } catch (deleteError) {
+      console.error("[admin] 공지사항 삭제 실패", deleteError);
+      setError("요청 처리에 실패했습니다. 잠시 후 다시 시도해주세요.");
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="flex-1 bg-white p-8">
+      {/* Page Header */}
+      <div className="mb-8 flex items-start justify-between">
+        <div>
+          <button
+            onClick={() => router.push("/admin/notices")}
+            className="mb-3 flex items-center gap-1 text-[14px] text-[#666] transition-colors hover:text-[#111]"
+          >
+            <BackIcon />
+            목록으로
+          </button>
+          <h1 className="text-[40px] font-bold leading-[1.3] tracking-[-1px] text-[#111]">
+            {isCreateMode ? "공지사항 작성" : "공지사항 수정"}
+          </h1>
+          <p className="mt-2 text-[16px] leading-normal tracking-[-0.4px] text-[#666]">
+            {isCreateMode ? "새 공지사항을 작성하세요." : "공지사항을 수정하세요."}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => void handleSubmit()}
+            disabled={isSubmitting || isLoading}
+            className="h-10 px-6 py-2.5 rounded-lg bg-[#004a9c] text-white text-[14px] font-medium leading-[1.43] tracking-[-0.35px] transition-colors hover:bg-[#003d8a] disabled:cursor-not-allowed disabled:bg-[#b3b3b3]"
+          >
+            {isCreateMode ? "등록" : "수정"}
+          </button>
+          {!isCreateMode && (
+            <button
+              onClick={() => void handleDelete()}
+              disabled={isSubmitting || isLoading}
+              className="h-10 px-6 py-2.5 border border-red-500 rounded-lg text-red-500 text-[14px] font-medium leading-[1.43] tracking-[-0.35px] transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              삭제
+            </button>
+          )}
+        </div>
+      </div>
+
+      {error && (
+        <p role="alert" className="mb-6 rounded-lg bg-red-50 px-4 py-3 text-[14px] text-red-600">
+          {error}
+        </p>
+      )}
+
+      {isLoading ? (
+        <p className="py-16 text-center text-[14px] text-[#999]">불러오는 중...</p>
+      ) : (
+        <>
+          {/* 기본 정보 */}
+          <section className="mb-8">
+            <h2 className="mb-6 text-[24px] font-semibold leading-[1.33] tracking-[-0.6px] text-[#1a1a1a]">
+              기본 정보
+            </h2>
+            <div className="flex flex-col gap-5">
+              <div>
+                <label className="mb-2 block text-[14px] font-medium text-[#333]">제목 *</label>
+                <input
+                  type="text"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                  placeholder="공지사항 제목을 입력하세요"
+                  className="h-10 w-full rounded-sm border border-[#e5e5e5] bg-white px-4 text-[14px] text-[#333] placeholder-[#999] outline-none focus:border-[#004a9c]"
+                />
+              </div>
+              <div>
+                <label className="mb-2 block text-[14px] font-medium text-[#333]">작성자</label>
+                <input
+                  type="text"
+                  value={authorName}
+                  disabled
+                  className="h-10 w-full rounded-sm border border-[#e5e5e5] bg-[#f5f5f5] px-4 text-[14px] text-[#999] outline-none"
+                />
+              </div>
+            </div>
+          </section>
+
+          {/* 공지 내용 */}
+          <section className="mb-8">
+            <h2 className="mb-6 text-[24px] font-semibold leading-[1.33] tracking-[-0.6px] text-[#1a1a1a]">
+              공지 내용
+            </h2>
+            <div>
+              <label className="mb-2 block text-[14px] font-medium text-[#333]">내용 *</label>
+              <textarea
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="공지 내용을 입력하세요"
+                className="min-h-75 w-full resize-y rounded-sm border border-[#e5e5e5] bg-white p-4 text-[14px] text-[#333] placeholder-[#999] outline-none focus:border-[#004a9c]"
+              />
+            </div>
+          </section>
+
+          {/* 파일 첨부 */}
+          <section>
+            <h2 className="mb-6 text-[24px] font-semibold leading-[1.33] tracking-[-0.6px] text-[#1a1a1a]">
+              파일 첨부
+            </h2>
+            <div>
+              <label className="mb-2 block text-[14px] font-medium text-[#333]">첨부파일</label>
+              <div className="flex flex-col gap-2">
+                {existingFiles.map((file) => (
+                  <div
+                    key={file.attachmentId}
+                    className="flex w-full items-center gap-3 rounded-lg border border-[#e5e5e5] bg-white p-3"
+                  >
+                    <span className="text-[#666]">
+                      <FileIcon />
+                    </span>
+                    <div className="flex-1">
+                      <p className="text-[14px] font-medium text-[#333]">{file.originalFilename}</p>
+                      <p className="text-[12px] text-[#999]">{formatFileSize(file.fileSize)}</p>
+                    </div>
+                    <button
+                      onClick={() => removeExistingFile(file.attachmentId)}
+                      aria-label={`${file.originalFilename} 삭제`}
+                      className="text-[#999] transition-colors hover:text-red-500"
+                    >
+                      <XIcon />
+                    </button>
+                  </div>
+                ))}
+                {newFiles.map((file, index) => (
+                  <div
+                    key={`${file.name}-${index}`}
+                    className="flex w-full items-center gap-3 rounded-lg border border-dashed border-[#004a9c]/40 bg-[#f8fafd] p-3"
+                  >
+                    <span className="text-[#004a9c]">
+                      <FileIcon />
+                    </span>
+                    <div className="flex-1">
+                      <p className="text-[14px] font-medium text-[#333]">{file.name}</p>
+                      <p className="text-[12px] text-[#999]">{formatFileSize(file.size)}</p>
+                    </div>
+                    <button
+                      onClick={() => removeNewFile(index)}
+                      aria-label={`${file.name} 삭제`}
+                      className="text-[#999] transition-colors hover:text-red-500"
+                    >
+                      <XIcon />
+                    </button>
+                  </div>
+                ))}
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  multiple
+                  onChange={handleNewFilesChange}
+                  className="hidden"
+                />
+                <button
+                  onClick={() => fileInputRef.current?.click()}
+                  className="flex h-10 w-fit items-center gap-2 rounded-lg border border-[#e5e5e5] px-4 text-[14px] font-medium text-[#333] transition-colors hover:bg-[#f9f9f9]"
+                >
+                  <FileIcon />
+                  파일 추가
+                </button>
+              </div>
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/screens/admin/notices/notices.tsx
+++ b/src/screens/admin/notices/notices.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import { getPosts } from "@/api/posts";
+import type { Post } from "@/api/posts";
+
+const PAGE_SIZE = 10;
+
+const formatDate = (isoDate: string): string => {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return "-";
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}.${month}.${day}`;
+};
+
+const PlusIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <line x1="12" y1="5" x2="12" y2="19" />
+    <line x1="5" y1="12" x2="19" y2="12" />
+  </svg>
+);
+
+const SearchIcon = () => (
+  <svg
+    width="16"
+    height="16"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <circle cx="11" cy="11" r="8" />
+    <line x1="21" y1="21" x2="16.65" y2="16.65" />
+  </svg>
+);
+
+export const AdminNoticesPage = () => {
+  const [search, setSearch] = useState("");
+  const [keyword, setKeyword] = useState("");
+  const [page, setPage] = useState(0);
+  const [notices, setNotices] = useState<Post[]>([]);
+  const [totalPages, setTotalPages] = useState(1);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // 입력이 멈추면 검색어를 반영하고 1페이지로 되돌린다(디바운스로 타이핑 중 과도한 요청 방지).
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setKeyword(search.trim());
+      setPage(0);
+    }, 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
+  const fetchNotices = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const response = await getPosts("NOTICE", {
+        page,
+        size: PAGE_SIZE,
+        sort: "LATEST",
+        keyword: keyword || undefined,
+      });
+      setNotices(response.content);
+      setTotalPages(Math.max(1, response.totalPages));
+    } catch (fetchError) {
+      console.error("[admin] 공지사항 목록 조회 실패", fetchError);
+      setError("공지사항 목록을 불러오지 못했습니다. 잠시 후 다시 시도해주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  }, [page, keyword]);
+
+  useEffect(() => {
+    void fetchNotices();
+  }, [fetchNotices]);
+
+  return (
+    <div className="flex-1 bg-white p-8">
+      {/* Page Header */}
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <h1 className="text-[32px] font-bold text-[#111]">공지사항 관리</h1>
+          <p className="mt-1 text-[14px] text-[#444]">공지사항을 작성하고 관리할 수 있습니다.</p>
+        </div>
+        <Link
+          href="/admin/notices/edit?id=new"
+          className="flex h-10 items-center gap-2 rounded-lg bg-[#004a9c] px-6 py-2.5 text-[14px] font-medium leading-[1.43] tracking-[-0.35px] text-white transition-colors hover:bg-[#003d8a]"
+        >
+          <PlusIcon />
+          공지사항 작성
+        </Link>
+      </div>
+
+      {/* Search */}
+      <div className="mb-4 flex h-10 items-center gap-2 rounded-md border border-[#e5e5e5] px-3 max-w-sm">
+        <span className="shrink-0 text-[#999]">
+          <SearchIcon />
+        </span>
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="제목 검색..."
+          className="flex-1 bg-transparent text-[14px] text-[#333] placeholder-[#999] outline-none"
+        />
+      </div>
+
+      {/* Table */}
+      <div className="w-full overflow-hidden rounded-lg border border-[#e5e5e5]">
+        {/* Header */}
+        <div className="flex h-12 items-center border-b-2 border-[#e5e5e5] bg-[#f2f2f2] px-5">
+          <span className="w-17.5 shrink-0 text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#333]">
+            순번
+          </span>
+          <span className="flex-1 text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#333]">
+            제목
+          </span>
+          <span className="w-27.5 shrink-0 text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#333]">
+            작성자
+          </span>
+          <span className="w-30 shrink-0 text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#333]">
+            등록일
+          </span>
+          <span className="w-30 shrink-0 text-[16px] font-semibold leading-normal tracking-[-0.4px] text-[#333]">
+            조회수
+          </span>
+        </div>
+
+        {/* Rows */}
+        {isLoading ? (
+          <div className="flex min-h-14 items-center justify-center px-5 py-8 text-[14px] text-[#999]">
+            불러오는 중...
+          </div>
+        ) : error ? (
+          <div className="flex min-h-14 items-center justify-center px-5 py-8 text-[14px] text-red-500">
+            {error}
+          </div>
+        ) : notices.length === 0 ? (
+          <div className="flex min-h-14 items-center justify-center px-5 py-8 text-[14px] text-[#999]">
+            {keyword ? "검색 결과가 없습니다." : "등록된 공지사항이 없습니다."}
+          </div>
+        ) : (
+          notices.map((notice) => (
+            <div
+              key={notice.postId}
+              className="flex min-h-14 items-center border-b border-[#e5e5e5] bg-white px-5 py-4 transition-colors hover:bg-[#f9f9f9]"
+            >
+              <span className="w-17.5 shrink-0 text-[14px] leading-[1.43] tracking-[-0.35px] text-[#333]">
+                {notice.postId}
+              </span>
+              <Link
+                href={`/admin/notices/edit?id=${notice.postId}`}
+                className="flex-1 truncate text-[14px] leading-[1.43] tracking-[-0.35px] text-[#333] hover:text-[#004a9c] hover:underline"
+              >
+                {notice.title}
+              </Link>
+              <span className="w-27.5 shrink-0 text-[14px] leading-[1.43] tracking-[-0.35px] text-[#333]">
+                {notice.authorName ?? "-"}
+              </span>
+              <span className="w-30 shrink-0 text-[14px] leading-[1.43] tracking-[-0.35px] text-[#333]">
+                {formatDate(notice.createdAt)}
+              </span>
+              <span className="w-30 shrink-0 text-[14px] leading-[1.43] tracking-[-0.35px] text-[#333]">
+                {notice.viewCount}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      {/* Pagination */}
+      <div className="mt-6 flex items-center justify-center gap-1">
+        {Array.from({ length: totalPages }, (_, i) => i).map((p) => (
+          <button
+            key={p}
+            onClick={() => setPage(p)}
+            className={[
+              "flex h-8 w-8 items-center justify-center rounded-md text-[14px] font-medium transition-colors",
+              page === p
+                ? "bg-[#004a9c] text-white"
+                : "text-[#666] hover:bg-[#004a9c]/5 hover:text-[#004a9c]",
+            ].join(" ")}
+          >
+            {p + 1}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/screens/home/home.tsx
+++ b/src/screens/home/home.tsx
@@ -335,7 +335,7 @@ export const HomePage: React.FC = () => {
                 <Card
                   key={post.postId}
                   variant="post"
-                  href={`/notice/${post.postId}`}
+                  href={`/notice/detail?id=${post.postId}`}
                   thumbnail={post.thumbnailImage}
                   tags={post.keywords}
                   title={post.title}

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -6,3 +6,9 @@ export { PortfolioListPage } from "./portfolio";
 export { PortfolioDetailPage } from "./portfolio-detail";
 export { PortfolioCreatePage } from "./portfolio-create";
 export { PortfolioEditPage } from "./portfolio-edit";
+export {
+  AdminSidebar,
+  AdminNoticesPage,
+  AdminNoticesEditPage,
+  AdminNoticesEditRoute,
+} from "./admin";

--- a/src/screens/index.ts
+++ b/src/screens/index.ts
@@ -4,3 +4,5 @@ export { AboutPage } from "./about";
 export { LoginPage } from "./login";
 export { PortfolioListPage } from "./portfolio";
 export { PortfolioDetailPage } from "./portfolio-detail";
+export { PortfolioCreatePage } from "./portfolio-create";
+export { PortfolioEditPage } from "./portfolio-edit";

--- a/src/screens/login/company-login-form.tsx
+++ b/src/screens/login/company-login-form.tsx
@@ -1,12 +1,11 @@
 import { Button, Input } from "@/shared/ui";
-import { AtSignIcon, BuildingIcon, LockIcon, MailIcon, UserIcon } from "@/shared/ui/icons";
+import { BuildingIcon, LockIcon, MailIcon, UserIcon } from "@/shared/ui/icons";
 
 export type CompanyAuthMode = "login" | "signup";
 
 export type CompanySignupValues = {
   companyName: string;
   name: string;
-  username: string;
   email: string;
   password: string;
   passwordConfirm: string;
@@ -69,20 +68,6 @@ export const CompanyLoginForm = ({
           placeholder="이름"
           aria-label="이름"
           leftIcon={<UserIcon width={20} />}
-          iconClassName={iconClassName}
-          size="large"
-          isFullWidth
-          className={signupInputClassName}
-        />
-        <Input
-          id="company-signup-username"
-          type="text"
-          value={signupValues.username}
-          onChange={(event) => onSignupValueChange("username", event.target.value)}
-          disabled={isSubmitting}
-          placeholder="아이디"
-          aria-label="아이디"
-          leftIcon={<AtSignIcon width={20} />}
           iconClassName={iconClassName}
           size="large"
           isFullWidth

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -36,7 +36,6 @@ const loginTabs: TabItem[] = [
 const initialCompanySignupValues: CompanySignupValues = {
   companyName: "",
   name: "",
-  username: "",
   email: "",
   password: "",
   passwordConfirm: "",
@@ -138,12 +137,11 @@ export const LoginPage = () => {
 
     const companyName = signupValues.companyName.trim();
     const name = signupValues.name.trim();
-    const username = signupValues.username.trim();
     const signupEmail = signupValues.email.trim();
     const signupPassword = signupValues.password;
     const passwordConfirm = signupValues.passwordConfirm;
 
-    if (!companyName || !name || !username || !signupEmail || !signupPassword || !passwordConfirm) {
+    if (!companyName || !name || !signupEmail || !signupPassword || !passwordConfirm) {
       showErrorModal("모든 정보를 입력해주세요.", "입력 오류");
       return;
     }

--- a/src/screens/notice-create/index.tsx
+++ b/src/screens/notice-create/index.tsx
@@ -1,0 +1,152 @@
+// src/screens/notice-create/index.tsx
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/shared/ui/button/button";
+import { Input } from "@/shared/ui/input/input";
+import { FileTextAltIcon } from "@/shared/ui/icons/index";
+// import { createNotice } from "@/api/notice";
+
+export function NoticeCreateScreen() {
+  const router = useRouter();
+
+  const [title, setTitle] = useState("");
+  const [author, setAuthor] = useState("");
+  const [description, setDescription] = useState("");
+  const [content, setContent] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  // 등록 로직 핸들러
+  const handleSubmit = async () => {
+    // 필수 필드 검증
+    if (!title.trim() || !author.trim() || !description.trim() || !content.trim()) {
+      alert("모든 필수 항목(*)을 입력해주세요.");
+      return;
+    }
+
+    try {
+      setIsSubmitting(true);
+
+      // await createNotice({
+      //   title,
+      //   description,
+      //   content,
+      //   userId: 10,
+      // });
+
+      alert("공지사항이 성공적으로 등록되었습니다.");
+      router.push("/notice");
+      router.refresh();
+    } catch {
+      alert("등록 중 오류가 발생했습니다.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto flex w-full max-w-[1440px] flex-1 flex-col px-6 pt-[160px] pb-[100px] md:px-12 xl:px-24 2xl:px-0">
+      {/* 1. 타이틀 영역 */}
+      <div className="mb-12 border-b border-gray-900 pb-6">
+        <h1 className="text-[40px] font-bold text-gray-900">공지사항 작성</h1>
+        <p className="mt-2 text-[15px] text-gray-500">중요한 공지사항을 작성하고 공유하세요</p>
+      </div>
+
+      {/* 2. 기본 정보 섹션 */}
+      <section className="mb-12 flex flex-col gap-6">
+        <h2 className="text-[20px] font-bold text-gray-900">기본 정보</h2>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-[15px] font-medium text-gray-700">제목 *</label>
+          <Input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            placeholder="공지사항 제목을 입력하세요"
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <label className="text-[15px] font-medium text-gray-700">작성자 *</label>
+          <Input
+            value={author}
+            onChange={(e) => setAuthor(e.target.value)}
+            placeholder="작성자 이름을 입력하세요"
+          />
+        </div>
+
+        {/* 간단한 소개 */}
+        <div className="flex flex-col gap-2">
+          <label className="text-[15px] font-medium text-gray-700">간단한 소개 *</label>
+          <Input
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="목록에 노출될 간단한 소개글을 입력하세요"
+          />
+        </div>
+      </section>
+
+      {/* 공지 내용 섹션 */}
+      <section className="mb-12 flex flex-col gap-6">
+        <h2 className="text-[20px] font-bold text-gray-900">공지 내용</h2>
+        <div className="flex flex-col gap-2">
+          <label className="text-[15px] font-medium text-gray-700">내용 *</label>
+          <textarea
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="공지사항 상세 내용을 입력하세요"
+            className="min-h-[400px] w-full rounded-md border border-gray-300 p-4 text-[15px] text-gray-800 outline-none focus:border-gray-900"
+          />
+        </div>
+      </section>
+
+      {/* 파일 첨부 섹션 */}
+      <section className="mb-12 flex flex-col gap-6">
+        <h2 className="text-[20px] font-bold text-gray-900">파일 첨부</h2>
+        <div className="flex flex-col gap-4">
+          <label className="text-[15px] font-medium text-gray-700">첨부파일</label>
+
+          <div className="flex h-[120px] cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-gray-300 bg-gray-50 transition-colors hover:bg-gray-100">
+            <FileTextAltIcon name="upload" className="mb-2 h-8 w-8 text-gray-400" />
+            <span className="font-medium text-gray-700">파일 추가</span>
+            <span className="mt-1 text-sm text-gray-500">Max. 50MB, HWP, PDF 등 지원</span>
+          </div>
+
+          <div className="flex items-center justify-between rounded-md border border-gray-200 p-4">
+            <div className="flex items-center gap-3">
+              <FileTextAltIcon name="file" className="h-6 w-6 text-gray-400" />
+              <span className="font-medium text-gray-700">Sample.pdf</span>
+              <span className="text-sm text-gray-400">2.5 MB</span>
+            </div>
+
+            <button className="px-1 text-lg font-medium text-gray-400 transition-colors hover:text-gray-900">
+              ✕
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* 하단 버튼 영역 */}
+      <div className="mt-8 flex justify-end gap-4 border-t border-gray-200 pt-8">
+        <Button
+          variant="secondary"
+          size="large"
+          onClick={() => router.back()}
+          className="w-[120px]"
+          disabled={isSubmitting}
+        >
+          취소
+        </Button>
+        <Button
+          variant="primary"
+          size="large"
+          onClick={handleSubmit}
+          className="w-[120px]"
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? "등록 중..." : "등록하기"}
+        </Button>
+      </div>
+    </main>
+  );
+}

--- a/src/screens/notice-create/index.tsx
+++ b/src/screens/notice-create/index.tsx
@@ -1,26 +1,40 @@
 // src/screens/notice-create/index.tsx
 "use client";
 
-import { useState } from "react";
+import { useState, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/shared/ui/button/button";
 import { Input } from "@/shared/ui/input/input";
-import { FileTextAltIcon } from "@/shared/ui/icons/index";
-// import { createNotice } from "@/api/notice";
+import { FileTextAltIcon, UploadIcon } from "@/shared/ui/icons/index";
+import { Footer } from "@/shared/ui/footer/footer";
+import { createNotice } from "@/api/notice";
 
 export function NoticeCreateScreen() {
   const router = useRouter();
 
   const [title, setTitle] = useState("");
-  const [author, setAuthor] = useState("");
   const [description, setDescription] = useState("");
   const [content, setContent] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [files, setFiles] = useState<File[]>([]);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // 파일 선택 핸들러
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files) {
+      const newFiles = Array.from(e.target.files);
+      setFiles((prev) => [...prev, ...newFiles]);
+    }
+  };
+
+  // 파일 삭제 핸들러
+  const handleRemoveFile = (indexToRemove: number) => {
+    setFiles((prev) => prev.filter((_, index) => index !== indexToRemove));
+  };
 
   // 등록 로직 핸들러
   const handleSubmit = async () => {
-    // 필수 필드 검증
-    if (!title.trim() || !author.trim() || !description.trim() || !content.trim()) {
+    if (!title.trim() || !description.trim() || !content.trim()) {
       alert("모든 필수 항목(*)을 입력해주세요.");
       return;
     }
@@ -28,17 +42,13 @@ export function NoticeCreateScreen() {
     try {
       setIsSubmitting(true);
 
-      // await createNotice({
-      //   title,
-      //   description,
-      //   content,
-      //   userId: 10,
-      // });
+      await createNotice({ title, description, content }, files);
 
       alert("공지사항이 성공적으로 등록되었습니다.");
       router.push("/notice");
       router.refresh();
-    } catch {
+    } catch (error) {
+      console.error("🚨 공지 등록 실패 상세 원인:", error);
       alert("등록 중 오류가 발생했습니다.");
     } finally {
       setIsSubmitting(false);
@@ -46,107 +56,123 @@ export function NoticeCreateScreen() {
   };
 
   return (
-    <main className="mx-auto flex w-full max-w-[1440px] flex-1 flex-col px-6 pt-[160px] pb-[100px] md:px-12 xl:px-24 2xl:px-0">
-      {/* 1. 타이틀 영역 */}
-      <div className="mb-12 border-b border-gray-900 pb-6">
-        <h1 className="text-[40px] font-bold text-gray-900">공지사항 작성</h1>
-        <p className="mt-2 text-[15px] text-gray-500">중요한 공지사항을 작성하고 공유하세요</p>
-      </div>
-
-      {/* 2. 기본 정보 섹션 */}
-      <section className="mb-12 flex flex-col gap-6">
-        <h2 className="text-[20px] font-bold text-gray-900">기본 정보</h2>
-
-        <div className="flex flex-col gap-2">
-          <label className="text-[15px] font-medium text-gray-700">제목 *</label>
-          <Input
-            value={title}
-            onChange={(e) => setTitle(e.target.value)}
-            placeholder="공지사항 제목을 입력하세요"
-          />
+    <>
+      <main className="mx-auto flex w-full max-w-[1440px] flex-1 flex-col px-6 pt-[160px] pb-[100px] md:px-12 xl:px-24 2xl:px-0">
+        {/* 1. 타이틀 영역 */}
+        <div className="mb-12 border-b border-gray-900 pb-6">
+          <h1 className="text-[40px] font-bold text-gray-900">공지사항 작성</h1>
+          <p className="mt-2 text-[15px] text-gray-500">중요한 공지사항을 작성하고 공유하세요</p>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <label className="text-[15px] font-medium text-gray-700">작성자 *</label>
-          <Input
-            value={author}
-            onChange={(e) => setAuthor(e.target.value)}
-            placeholder="작성자 이름을 입력하세요"
-          />
-        </div>
+        {/* 2. 기본 정보 섹션 */}
+        <section className="mb-12 flex flex-col gap-6">
+          <h2 className="text-[20px] font-bold text-gray-900">기본 정보</h2>
 
-        {/* 간단한 소개 */}
-        <div className="flex flex-col gap-2">
-          <label className="text-[15px] font-medium text-gray-700">간단한 소개 *</label>
-          <Input
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            placeholder="목록에 노출될 간단한 소개글을 입력하세요"
-          />
-        </div>
-      </section>
-
-      {/* 공지 내용 섹션 */}
-      <section className="mb-12 flex flex-col gap-6">
-        <h2 className="text-[20px] font-bold text-gray-900">공지 내용</h2>
-        <div className="flex flex-col gap-2">
-          <label className="text-[15px] font-medium text-gray-700">내용 *</label>
-          <textarea
-            value={content}
-            onChange={(e) => setContent(e.target.value)}
-            placeholder="공지사항 상세 내용을 입력하세요"
-            className="min-h-[400px] w-full rounded-md border border-gray-300 p-4 text-[15px] text-gray-800 outline-none focus:border-gray-900"
-          />
-        </div>
-      </section>
-
-      {/* 파일 첨부 섹션 */}
-      <section className="mb-12 flex flex-col gap-6">
-        <h2 className="text-[20px] font-bold text-gray-900">파일 첨부</h2>
-        <div className="flex flex-col gap-4">
-          <label className="text-[15px] font-medium text-gray-700">첨부파일</label>
-
-          <div className="flex h-[120px] cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-gray-300 bg-gray-50 transition-colors hover:bg-gray-100">
-            <FileTextAltIcon name="upload" className="mb-2 h-8 w-8 text-gray-400" />
-            <span className="font-medium text-gray-700">파일 추가</span>
-            <span className="mt-1 text-sm text-gray-500">Max. 50MB, HWP, PDF 등 지원</span>
+          <div className="flex flex-col gap-2">
+            <label className="text-[15px] font-medium text-gray-700">제목 *</label>
+            <Input
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="공지사항 제목을 입력하세요"
+            />
           </div>
 
-          <div className="flex items-center justify-between rounded-md border border-gray-200 p-4">
-            <div className="flex items-center gap-3">
-              <FileTextAltIcon name="file" className="h-6 w-6 text-gray-400" />
-              <span className="font-medium text-gray-700">Sample.pdf</span>
-              <span className="text-sm text-gray-400">2.5 MB</span>
+          {/* 간단한 소개 */}
+          <div className="flex flex-col gap-2">
+            <label className="text-[15px] font-medium text-gray-700">간단한 소개 *</label>
+            <Input
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder="목록에 노출될 간단한 소개글을 입력하세요"
+            />
+          </div>
+        </section>
+
+        {/* 공지 내용 섹션 */}
+        <section className="mb-12 flex flex-col gap-6">
+          <h2 className="text-[20px] font-bold text-gray-900">공지 내용</h2>
+          <div className="flex flex-col gap-2">
+            <label className="text-[15px] font-medium text-gray-700">내용 *</label>
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value)}
+              placeholder="공지사항 상세 내용을 입력하세요"
+              className="min-h-[400px] w-full rounded-md border border-gray-300 p-4 text-[15px] text-gray-800 outline-none focus:border-gray-900"
+            />
+          </div>
+        </section>
+
+        {/* 파일 첨부 섹션 */}
+        <section className="mb-12 flex flex-col gap-6">
+          <h2 className="text-[20px] font-bold text-gray-900">파일 첨부</h2>
+          <div className="flex flex-col gap-4">
+            <label className="text-[15px] font-medium text-gray-700">첨부파일</label>
+
+            {/* input 태그 */}
+            <input
+              type="file"
+              multiple
+              className="hidden"
+              ref={fileInputRef}
+              onChange={handleFileChange}
+            />
+
+            <div
+              onClick={() => fileInputRef.current?.click()}
+              className="flex h-[120px] cursor-pointer flex-col items-center justify-center rounded-md border-2 border-dashed border-gray-300 bg-gray-50 transition-colors hover:bg-gray-100"
+            >
+              <UploadIcon className="mb-2 h-8 w-8 text-gray-400" />
+              <span className="font-medium text-gray-700">파일 추가</span>
+              <span className="mt-1 text-sm text-gray-500">PDF, DOCX, PPTX, ZIP, 이미지 등</span>
             </div>
 
-            <button className="px-1 text-lg font-medium text-gray-400 transition-colors hover:text-gray-900">
-              ✕
-            </button>
+            {/* 파일목록 렌더링 */}
+            {files.map((file, index) => (
+              <div
+                key={`${file.name}-${index}`}
+                className="flex items-center justify-between rounded-md border border-gray-200 p-4"
+              >
+                <div className="flex items-center gap-3">
+                  <FileTextAltIcon className="h-6 w-6 text-gray-400" />
+                  <span className="font-medium text-gray-700">{file.name}</span>
+                  <span className="text-sm text-gray-400">
+                    {(file.size / (1024 * 1024)).toFixed(2)} MB
+                  </span>
+                </div>
+                <button
+                  onClick={() => handleRemoveFile(index)}
+                  className="px-1 text-lg font-medium text-gray-400 transition-colors hover:text-gray-900"
+                >
+                  ✕
+                </button>
+              </div>
+            ))}
           </div>
-        </div>
-      </section>
+        </section>
 
-      {/* 하단 버튼 영역 */}
-      <div className="mt-8 flex justify-end gap-4 border-t border-gray-200 pt-8">
-        <Button
-          variant="secondary"
-          size="large"
-          onClick={() => router.back()}
-          className="w-[120px]"
-          disabled={isSubmitting}
-        >
-          취소
-        </Button>
-        <Button
-          variant="primary"
-          size="large"
-          onClick={handleSubmit}
-          className="w-[120px]"
-          disabled={isSubmitting}
-        >
-          {isSubmitting ? "등록 중..." : "등록하기"}
-        </Button>
-      </div>
-    </main>
+        {/* 하단 버튼 영역 */}
+        <div className="mt-8 flex justify-end gap-4 border-t border-gray-200 pt-8">
+          <Button
+            variant="secondary"
+            size="large"
+            onClick={() => router.back()}
+            className="w-[120px]"
+            disabled={isSubmitting}
+          >
+            취소
+          </Button>
+          <Button
+            variant="primary"
+            size="large"
+            onClick={handleSubmit}
+            className="w-[120px]"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? "등록 중..." : "등록하기"}
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </>
   );
 }

--- a/src/screens/notice-detail/index.tsx
+++ b/src/screens/notice-detail/index.tsx
@@ -3,7 +3,7 @@
 
 import { useRouter } from "next/navigation";
 import { Button } from "@/shared/ui/button/button";
-import { Footer } from "@/shared/ui/footer";
+import { Footer } from "@/shared/ui/footer/footer";
 import type { Notice } from "@/api/notice";
 
 interface NoticeDetailScreenProps {

--- a/src/screens/notice-detail/index.tsx
+++ b/src/screens/notice-detail/index.tsx
@@ -1,0 +1,127 @@
+// src/screens/notice-detail/index.tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Button } from "@/shared/ui/button/button";
+import { Footer } from "@/shared/ui/footer";
+import type { Notice } from "@/api/notice";
+
+interface NoticeDetailScreenProps {
+  notice: Notice;
+}
+
+export function NoticeDetailScreen({ notice }: NoticeDetailScreenProps) {
+  const router = useRouter();
+
+  const formatDate = (dateString: string) => {
+    if (!dateString) return "-";
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}.`;
+  };
+
+  // 파일 크기 포맷팅
+  const formatFileSize = (bytes: number) => {
+    if (bytes === 0) return "0 Bytes";
+    const k = 1024;
+    const sizes = ["Bytes", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return parseFloat((bytes / Math.pow(k, i)).toFixed(1)) + " " + sizes[i];
+  };
+
+  return (
+    <>
+      <main className="mx-auto flex w-full max-w-[1440px] flex-1 flex-col gap-[40px] px-4 pt-[160px] pb-[100px]">
+        {/* 타이틀 영역 */}
+        <h1 className="text-center text-[40px] font-bold leading-[1.3] tracking-[-0.025em] text-gray-900">
+          공지사항
+        </h1>
+
+        {/* 상세 내용 테이블 영역 */}
+        <div className="w-full text-[15px] text-gray-800">
+          <div className="flex min-h-[48px] items-center justify-center gap-[10px] border-b border-t-2 border-b-gray-200 border-t-gray-900 bg-gray-50 px-5 py-3">
+            <span className="text-center font-semibold">{notice.title}</span>
+          </div>
+
+          <div className="flex flex-wrap md:flex-nowrap border-b border-gray-200">
+            <div className="flex min-h-[48px] w-full shrink-0 items-center gap-[10px] border-b border-r border-gray-200 bg-gray-50 px-5 py-3 font-medium text-gray-700 md:w-[180px] md:border-b-0">
+              작성자
+            </div>
+            <div className="flex min-h-[48px] w-full shrink-0 items-center gap-[10px] border-b border-gray-200 px-5 py-3 md:w-[540px] md:border-b-0">
+              {notice.userId ? `회원(ID: ${notice.userId})` : "관리자"}
+            </div>
+
+            <div className="flex min-h-[48px] w-full shrink-0 items-center gap-[10px] border-b border-l border-r border-gray-200 bg-gray-50 px-5 py-3 font-medium text-gray-700 md:w-[180px] md:border-b-0 md:border-l-0">
+              작성일
+            </div>
+            <div className="flex min-h-[48px] w-full shrink-0 items-center gap-[10px] px-5 py-3 md:w-[540px]">
+              {formatDate(notice.createdAt)}
+            </div>
+          </div>
+
+          {/* 본문 내용 영역 */}
+          <div className="flex flex-col min-h-[576px] w-full border-b border-gray-200 py-6 px-5 gap-[10px] whitespace-pre-wrap leading-relaxed text-[16px] text-gray-800">
+            {notice.images && notice.images.length > 0 && (
+              <div className="flex flex-col gap-4 mb-4">
+                {notice.images.map((img) => (
+                  <img
+                    key={img.attachmentId}
+                    src={img.filePath}
+                    alt={img.originalFilename || "본문 첨부 이미지"}
+                    className="max-w-full md:max-w-[400px] h-auto rounded-md object-contain" // 첨부 이미지 크기 조절 필요
+                  />
+                ))}
+              </div>
+            )}
+
+            {/* 실제 텍스트 본문 */}
+            <div>{notice.content}</div>
+          </div>
+
+          {/* 파일 첨부 영역 */}
+          <div className="flex flex-wrap md:flex-nowrap border-b border-gray-200">
+            <div className="flex min-h-[48px] w-full shrink-0 items-center gap-[10px] border-b border-r border-gray-200 bg-gray-50 px-5 py-3 font-medium text-gray-700 md:w-[180px] md:border-b-0">
+              첨부파일
+            </div>
+
+            {/* 첨부파일 리스트 영역 */}
+            <div className="flex min-h-[48px] flex-1 flex-col justify-center gap-2 px-5 py-3">
+              {notice.files && notice.files.length > 0 ? (
+                notice.files.map((file) => (
+                  <a
+                    key={file.attachmentId}
+                    href={file.filePath}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="flex items-center gap-2 text-gray-600 hover:text-gray-900 hover:underline w-fit"
+                  >
+                    <span className="font-medium">{file.originalFilename}</span>
+                    {/* 파일 크기 표기 */}
+                    <span className="text-xs text-gray-400">({formatFileSize(file.fileSize)})</span>
+                  </a>
+                ))
+              ) : (
+                <span className="text-[14px] text-gray-500">첨부파일이 없습니다.</span>
+              )}
+            </div>
+          </div>
+        </div>
+
+        {/* 목록 돌아가기 버튼 */}
+        <div className="mt-8 flex justify-center">
+          <Button
+            variant="secondary"
+            size="large"
+            onClick={() => router.push("/notice")}
+            className="w-[120px]"
+          >
+            목록
+          </Button>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/src/screens/notice/index.tsx
+++ b/src/screens/notice/index.tsx
@@ -1,0 +1,74 @@
+// src/screens/notice/index.tsx
+"use client";
+
+import { useRouter } from "next/navigation";
+import { Footer } from "@/shared/ui/footer";
+import { Table, type TableColumn, type TableRowData } from "@/shared/ui/lists/lists";
+import { Pagination } from "@/shared/ui/pagination/pagination";
+import type { Notice } from "@/api/notice";
+
+interface NoticeScreenProps {
+  notices: Notice[];
+  currentPage: number;
+  totalPages: number;
+}
+
+export function NoticeScreen({ notices, currentPage, totalPages }: NoticeScreenProps) {
+  const router = useRouter();
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, "0");
+    const day = String(date.getDate()).padStart(2, "0");
+    return `${year}.${month}.${day}.`;
+  };
+
+  const noticeColumns: TableColumn[] = [
+    { id: "postId", label: "순번", width: "sm", align: "center" },
+    { id: "title", label: "제목", width: "fill", align: "center" },
+    { id: "createdAt", label: "등록일", width: "md", align: "center" },
+    { id: "viewCount", label: "조회수", width: "md", align: "center" },
+  ];
+
+  const tableData: TableRowData[] = notices.map((notice) => ({
+    id: notice.postId.toString(),
+    postId: notice.postId,
+    title: <div className="truncate text-gray-800 hover:underline">{notice.title}</div>,
+    createdAt: formatDate(notice.createdAt),
+    viewCount: notice.viewCount,
+  }));
+
+  const handlePageChange = (page: number) => {
+    router.push(`/notice?page=${page}`);
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col bg-white">
+      <main className="mx-auto flex-1 w-full max-w-[1440px] px-4 pt-[160px] pb-[100px]">
+        <h1 className="mb-12 text-center text-[40px] font-bold leading-[1.3] tracking-[-0.025em] text-gray-900">
+          공지사항
+        </h1>
+
+        <div className="w-full border-t-2 border-gray-900">
+          <Table
+            columns={noticeColumns}
+            data={tableData}
+            isEmpty={notices.length === 0}
+            onRowClick={(id) => router.push(`/notice/detail?id=${id}`)}
+          />
+        </div>
+
+        <div className="mt-12 flex items-center justify-center">
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
+        </div>
+      </main>
+
+      <Footer />
+    </div>
+  );
+}

--- a/src/screens/portfolio-create/index.ts
+++ b/src/screens/portfolio-create/index.ts
@@ -1,0 +1,1 @@
+export { PortfolioCreatePage } from "./portfolio-create-page";

--- a/src/screens/portfolio-create/portfolio-create-page.tsx
+++ b/src/screens/portfolio-create/portfolio-create-page.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import type { PortfolioBoardType } from "@/api/posts";
+import { useAuthReady } from "@/lib/auth";
+import { useCreatePortfolio } from "@/lib/posts";
+import { PortfolioForm, type PortfolioFormSubmitValue } from "@/screens/portfolio-form";
+import { Spinner } from "@/shared/ui/spinner/spinner";
+
+// 작성 페이지는 포트폴리오 게시판 전용.
+const BOARD_TYPE: PortfolioBoardType = "PORTFOLIO";
+
+export const PortfolioCreatePage = () => {
+  const router = useRouter();
+  const { isReady: isAuthReady, isAuthenticated } = useAuthReady();
+  const { submit, isSubmitting, error: submitError } = useCreatePortfolio();
+
+  // 미인증 사용자는 로그인 페이지로 보낸다(작성은 로그인 필수).
+  useEffect(() => {
+    if (isAuthReady && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [isAuthReady, isAuthenticated, router]);
+
+  const handleSubmit = async ({ fields, thumbnail, images, files }: PortfolioFormSubmitValue) => {
+    const created = await submit(
+      BOARD_TYPE,
+      {
+        title: fields.title,
+        description: fields.description,
+        content: fields.content,
+        videoLink: fields.videoLink,
+        githubLink: fields.githubLink,
+        visibility: fields.visibility,
+        keywordIds: fields.keywordIds,
+      },
+      { thumbnail, images, files },
+    );
+
+    if (created) {
+      router.push(`/portfolio/detail?id=${created.postId}&type=${created.boardType}`);
+    }
+  };
+
+  // 인증 확인 전이거나 미인증(리다이렉트 대기) 상태에서는 폼을 노출하지 않는다.
+  if (!isAuthReady || !isAuthenticated) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div
+          className="flex items-center justify-center py-40"
+          role="status"
+          aria-label="불러오는 중"
+        >
+          <Spinner size="large" />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <PortfolioForm
+      heading="포트폴리오 작성"
+      headingDescription="프로젝트를 공유하고 다른 사람들과 소통하세요"
+      submitLabel="저장하기"
+      isSubmitting={isSubmitting}
+      submitError={submitError}
+      onSubmit={handleSubmit}
+      onCancel={() => router.push("/portfolio")}
+    />
+  );
+};

--- a/src/screens/portfolio-detail/portfolio-detail-page.tsx
+++ b/src/screens/portfolio-detail/portfolio-detail-page.tsx
@@ -4,7 +4,10 @@ import { useEffect, useRef, useState, type RefObject } from "react";
 import { useRouter } from "next/navigation";
 import { getPortfolioDetail, type PortfolioBoardType, type PortfolioDetail } from "@/api/posts";
 import { useAuthReady } from "@/lib/auth";
+import { useDeletePortfolio } from "@/lib/posts";
+import { useCurrentUserId } from "@/lib/user";
 import { Button } from "@/shared/ui/button/button";
+import { Modal, ModalContent, ModalFooter, ModalHeader } from "@/shared/ui/modal";
 import { EmptyState } from "@/shared/ui/empty-states/empty-states";
 import { RichEditor } from "@/shared/ui/rich-editor";
 import { Spinner } from "@/shared/ui/spinner/spinner";
@@ -60,7 +63,10 @@ const toDetailFetchKey = (boardType: PortfolioBoardType, postId: number): string
 export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPageProps) => {
   const router = useRouter();
   const { isReady: isAuthReady, isAuthenticated } = useAuthReady();
+  const { userId: currentUserId } = useCurrentUserId();
+  const { remove: removePortfolio, isDeleting, error: deleteError } = useDeletePortfolio();
   const [result, setResult] = useState<DetailFetchResult | null>(null);
+  const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
 
   const fetchKey = toDetailFetchKey(boardType, postId);
   const hasMatchingResult = result?.fetchKey === fetchKey;
@@ -140,13 +146,44 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
 
     if (!detail) return null;
 
+    const isOwner = currentUserId != null && currentUserId === detail.userId;
+
+    // 추가 이미지 갤러리: 상단 히어로와 중복되는 썸네일 파일은 제외한다.
+    const galleryImages = detail.images
+      .filter((image) => image.filePath !== detail.thumbnailImage)
+      .sort((a, b) => a.displayOrder - b.displayOrder);
+
+    const handleDelete = async () => {
+      const isDeleted = await removePortfolio(detail.boardType, detail.postId);
+      if (isDeleted) {
+        setIsDeleteModalOpen(false);
+        router.push("/portfolio");
+      }
+    };
+
     return (
       <>
         {/* 헤더: 좋아요 + 썸네일/상세 정보 */}
         <div className="mx-auto max-w-[1440px] px-6 py-20">
           <div className="flex flex-col gap-10">
-            {/* 좋아요 */}
-            <div className="flex justify-end">
+            {/* 삭제·편집(작성자 전용) + 좋아요 */}
+            <div className="flex items-center justify-end gap-3">
+              {isOwner && (
+                <>
+                  <Button variant="danger" size="small" onClick={() => setIsDeleteModalOpen(true)}>
+                    삭제
+                  </Button>
+                  <Button
+                    variant="secondary"
+                    size="small"
+                    onClick={() =>
+                      router.push(`/portfolio/edit?id=${detail.postId}&type=${detail.boardType}`)
+                    }
+                  >
+                    편집
+                  </Button>
+                </>
+              )}
               <PortfolioLikeButton
                 postId={detail.postId}
                 initialLiked={Boolean(detail.liked)}
@@ -244,9 +281,27 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
           <div className="flex flex-col gap-20">
             {/* 소개: 본문 + 태그 */}
             <div ref={introRef} className="flex flex-col gap-10 pt-[60px]">
+              {/* 추가 이미지 갤러리 (각 470x265, 간격 15px, 1440 기준 3열) */}
+              {galleryImages.length > 0 && (
+                <section className="grid grid-cols-1 gap-[15px] sm:grid-cols-2 lg:grid-cols-3">
+                  {galleryImages.map((image) => (
+                    <div
+                      key={image.attachmentId}
+                      className="aspect-[470/265] w-full overflow-hidden rounded-lg bg-[var(--color-gray-100,#f2f2f2)]"
+                    >
+                      <img
+                        src={image.filePath}
+                        alt={image.originalFilename}
+                        className="h-full w-full object-cover"
+                      />
+                    </div>
+                  ))}
+                </section>
+              )}
+
               {/* 본문 */}
               <section className="flex flex-col gap-5">
-                <h2 className={sectionTitleClasses}>포트폴리오</h2>
+                <h2 className={sectionTitleClasses}>상세 설명</h2>
                 <RichEditor content={detail.content} isEditable={false} />
               </section>
 
@@ -263,13 +318,11 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
               )}
             </div>
 
-            {/* 첨부파일 (이미지 + 파일 첨부 모두 표시) */}
+            {/* 첨부파일 (파일만 표시 — 이미지는 위 갤러리로 분리) */}
             <section ref={filesRef} className="flex flex-col gap-5 pt-[60px]">
               <h2 className={sectionTitleClasses}>첨부파일</h2>
               <PortfolioAttachments
-                attachments={[...detail.images, ...detail.files].sort(
-                  (a, b) => a.displayOrder - b.displayOrder,
-                )}
+                attachments={[...detail.files].sort((a, b) => a.displayOrder - b.displayOrder)}
               />
             </section>
 
@@ -286,6 +339,33 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
             </div>
           </div>
         </div>
+
+        {/* 삭제 확인 모달 (작성자 전용) */}
+        <Modal isOpen={isDeleteModalOpen} onClose={() => setIsDeleteModalOpen(false)}>
+          <ModalHeader title="포트폴리오 삭제" onClose={() => setIsDeleteModalOpen(false)} />
+          <ModalContent>
+            <p className="text-[15px] leading-[1.6] text-[var(--color-gray-700,#4d4d4d)]">
+              정말 이 포트폴리오를 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+            </p>
+            {deleteError && (
+              <p className="mt-3 text-[14px] font-medium text-[var(--color-error-500,#ef4444)]">
+                삭제에 실패했습니다. 잠시 후 다시 시도해주세요.
+              </p>
+            )}
+          </ModalContent>
+          <ModalFooter>
+            <Button
+              variant="secondary"
+              onClick={() => setIsDeleteModalOpen(false)}
+              disabled={isDeleting}
+            >
+              취소
+            </Button>
+            <Button variant="danger" onClick={handleDelete} isLoading={isDeleting}>
+              삭제
+            </Button>
+          </ModalFooter>
+        </Modal>
       </>
     );
   };

--- a/src/screens/portfolio-edit/index.ts
+++ b/src/screens/portfolio-edit/index.ts
@@ -1,0 +1,2 @@
+export { PortfolioEditPage } from "./portfolio-edit-page";
+export { PortfolioEditRoute } from "./portfolio-edit-route";

--- a/src/screens/portfolio-edit/portfolio-edit-page.tsx
+++ b/src/screens/portfolio-edit/portfolio-edit-page.tsx
@@ -1,0 +1,187 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { getPortfolioDetail, type PortfolioBoardType, type PortfolioDetail } from "@/api/posts";
+import { useAuthReady } from "@/lib/auth";
+import { useUpdatePortfolio } from "@/lib/posts";
+import { useCurrentUserId } from "@/lib/user";
+import {
+  PortfolioForm,
+  type PortfolioFormInitialValues,
+  type PortfolioFormSubmitValue,
+} from "@/screens/portfolio-form";
+import { Button } from "@/shared/ui/button/button";
+import { EmptyState } from "@/shared/ui/empty-states/empty-states";
+import { Spinner } from "@/shared/ui/spinner/spinner";
+
+export type PortfolioEditPageProps = {
+  postId: number;
+  boardType: PortfolioBoardType;
+};
+
+const toInitialValues = (detail: PortfolioDetail): PortfolioFormInitialValues => ({
+  title: detail.title,
+  description: detail.description ?? "",
+  content: detail.content ?? "",
+  videoLink: detail.videoLink ?? "",
+  githubLink: detail.githubLink ?? "",
+  visibility: detail.visibility,
+  keywordIds: detail.keywords.map((keyword) => keyword.keywordId),
+});
+
+const LOAD_ERROR_MESSAGE = "포트폴리오를 불러오지 못했습니다.";
+
+type EditFetchResult = {
+  fetchKey: string;
+  detail?: PortfolioDetail;
+  error?: string;
+};
+
+const toEditFetchKey = (boardType: PortfolioBoardType, postId: number): string =>
+  `${boardType}|${postId}`;
+
+const CenteredMain = ({ children }: { children: React.ReactNode }) => (
+  <main className="min-h-screen bg-white">
+    <div className="mx-auto max-w-[1440px] px-6 py-20">{children}</div>
+  </main>
+);
+
+export const PortfolioEditPage = ({ postId, boardType }: PortfolioEditPageProps) => {
+  const router = useRouter();
+  const { isReady: isAuthReady, isAuthenticated } = useAuthReady();
+  const { userId: currentUserId, isResolved: isProfileResolved } = useCurrentUserId();
+  const { submit, isSubmitting, error: submitError } = useUpdatePortfolio();
+
+  const [result, setResult] = useState<EditFetchResult | null>(null);
+
+  // 현재 파라미터와 일치하는 조회 결과만 사용한다(edit?id=1 → id=2 이동 시 이전 글 노출/제출 방지).
+  const fetchKey = toEditFetchKey(boardType, postId);
+  const hasMatchingResult = result?.fetchKey === fetchKey;
+  const detail = hasMatchingResult ? result.detail : undefined;
+  const loadError = hasMatchingResult ? (result.error ?? null) : null;
+
+  // 미인증 사용자는 로그인 페이지로 보낸다(수정은 로그인 필수).
+  useEffect(() => {
+    if (isAuthReady && !isAuthenticated) {
+      router.replace("/login");
+    }
+  }, [isAuthReady, isAuthenticated, router]);
+
+  useEffect(() => {
+    if (!isAuthReady || !isAuthenticated) return;
+
+    let isCancelled = false;
+
+    getPortfolioDetail(boardType, postId)
+      .then((response) => {
+        if (isCancelled) return;
+        setResult({ fetchKey, detail: response });
+      })
+      .catch((cause: unknown) => {
+        if (isCancelled) return;
+        console.error(LOAD_ERROR_MESSAGE, cause);
+        setResult({ fetchKey, error: LOAD_ERROR_MESSAGE });
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [isAuthReady, isAuthenticated, boardType, postId, fetchKey]);
+
+  const handleSubmit = async ({
+    fields,
+    thumbnail,
+    images,
+    files,
+    deleteAttachmentIds,
+  }: PortfolioFormSubmitValue) => {
+    const updated = await submit(
+      boardType,
+      postId,
+      {
+        title: fields.title,
+        description: fields.description,
+        content: fields.content,
+        videoLink: fields.videoLink,
+        githubLink: fields.githubLink,
+        visibility: fields.visibility,
+        keywordIds: fields.keywordIds,
+        deleteAttachmentIds,
+      },
+      { thumbnail, images, files },
+    );
+
+    if (updated) {
+      router.push(`/portfolio/detail?id=${updated.postId}&type=${updated.boardType}`);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <CenteredMain>
+        <EmptyState
+          variant="error"
+          title="포트폴리오를 불러오지 못했습니다"
+          description={loadError}
+          hasBackground
+        />
+      </CenteredMain>
+    );
+  }
+
+  // 인증/상세/프로필 확정 전에는 로딩 표시 (소유자 판별을 위해 프로필까지 대기)
+  if (!isAuthReady || !isAuthenticated || !detail || !isProfileResolved) {
+    return (
+      <CenteredMain>
+        <div
+          className="flex items-center justify-center py-24"
+          role="status"
+          aria-label="불러오는 중"
+        >
+          <Spinner size="large" />
+        </div>
+      </CenteredMain>
+    );
+  }
+
+  const isOwner = currentUserId != null && currentUserId === detail.userId;
+  if (!isOwner) {
+    return (
+      <CenteredMain>
+        <EmptyState
+          variant="no-content"
+          title="수정 권한이 없습니다"
+          description="본인이 작성한 포트폴리오만 수정할 수 있습니다."
+          hasBackground
+        />
+        <div className="mt-6 flex justify-center">
+          <Button
+            variant="primary"
+            size="large"
+            onClick={() => router.push(`/portfolio/detail?id=${postId}&type=${boardType}`)}
+          >
+            상세로 돌아가기
+          </Button>
+        </div>
+      </CenteredMain>
+    );
+  }
+
+  return (
+    <PortfolioForm
+      key={fetchKey}
+      heading="포트폴리오 수정"
+      headingDescription="프로젝트 내용을 최신 상태로 업데이트하세요"
+      submitLabel="수정하기"
+      isSubmitting={isSubmitting}
+      submitError={submitError}
+      onSubmit={handleSubmit}
+      onCancel={() => router.push(`/portfolio/detail?id=${postId}&type=${boardType}`)}
+      initialValues={toInitialValues(detail)}
+      existingThumbnailUrl={detail.thumbnailImage}
+      existingImages={detail.images}
+      existingFiles={detail.files}
+    />
+  );
+};

--- a/src/screens/portfolio-edit/portfolio-edit-route.tsx
+++ b/src/screens/portfolio-edit/portfolio-edit-route.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { PORTFOLIO_BOARD_TYPES_ALL, type PortfolioBoardType } from "@/api/posts";
+import { EmptyState } from "@/shared/ui/empty-states/empty-states";
+import { PortfolioEditPage } from "./portfolio-edit-page";
+
+const isPortfolioBoardType = (value: string | null): value is PortfolioBoardType =>
+  value !== null && (PORTFOLIO_BOARD_TYPES_ALL as string[]).includes(value);
+
+export const PortfolioEditRoute = () => {
+  const searchParams = useSearchParams();
+  const idParam = searchParams.get("id");
+  const postId = Number(idParam);
+  const typeParam = searchParams.get("type");
+  const boardType: PortfolioBoardType = isPortfolioBoardType(typeParam) ? typeParam : "PORTFOLIO";
+
+  const isValidPostId = Boolean(idParam) && Number.isInteger(postId) && postId > 0;
+
+  if (!isValidPostId) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div className="mx-auto max-w-[1440px] px-6 py-16">
+          <EmptyState
+            variant="no-content"
+            title="잘못된 접근입니다"
+            description="유효한 포트폴리오를 찾을 수 없습니다."
+            hasBackground
+          />
+        </div>
+      </main>
+    );
+  }
+
+  return <PortfolioEditPage postId={postId} boardType={boardType} />;
+};

--- a/src/screens/portfolio-form/index.ts
+++ b/src/screens/portfolio-form/index.ts
@@ -1,0 +1,6 @@
+export { PortfolioForm } from "./portfolio-form";
+export type {
+  PortfolioFormInitialValues,
+  PortfolioFormProps,
+  PortfolioFormSubmitValue,
+} from "./portfolio-form";

--- a/src/screens/portfolio-form/portfolio-form.tsx
+++ b/src/screens/portfolio-form/portfolio-form.tsx
@@ -1,0 +1,519 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import type { PortfolioAttachment, PortfolioVisibility } from "@/api/posts";
+import { useKeywords } from "@/lib/posts";
+import { Button } from "@/shared/ui/button/button";
+import {
+  FileListItem,
+  FileUploader,
+  ThumbnailUploader,
+} from "@/shared/ui/file-uploader/file-uploader";
+import { FormErrorMessage, FormField, FormHelperText, FormLabel } from "@/shared/ui/form/form";
+import { SelectDropdown } from "@/shared/ui/dropdown";
+import { Input, Textarea } from "@/shared/ui/input/input";
+import { RichEditor } from "@/shared/ui/rich-editor";
+import { Spinner } from "@/shared/ui/spinner/spinner";
+import { Tag } from "@/shared/ui/tag/tag";
+import { XIcon } from "@/shared/ui/icons";
+
+const MAX_TITLE_LENGTH = 100;
+const MAX_DESCRIPTION_LENGTH = 200;
+const ATTACHMENT_ACCEPT = ".pdf,.doc,.docx,.ppt,.pptx,.zip,.hwp,.txt";
+
+export type PortfolioFormInitialValues = {
+  title: string;
+  description: string;
+  content: string;
+  videoLink: string;
+  githubLink: string;
+  visibility: PortfolioVisibility;
+  keywordIds: number[];
+};
+
+export type PortfolioFormSubmitValue = {
+  fields: {
+    title: string;
+    description?: string;
+    content?: string;
+    videoLink?: string;
+    githubLink?: string;
+    visibility: PortfolioVisibility;
+    keywordIds: number[];
+  };
+  thumbnail: File | null;
+  images: File[];
+  files: File[];
+  deleteAttachmentIds: number[];
+};
+
+export type PortfolioFormProps = {
+  heading: string;
+  headingDescription: string;
+  submitLabel: string;
+  isSubmitting: boolean;
+  submitError: Error | null;
+  onSubmit: (value: PortfolioFormSubmitValue) => void;
+  onCancel: () => void;
+  initialValues?: PortfolioFormInitialValues;
+  existingThumbnailUrl?: string | null;
+  existingImages?: PortfolioAttachment[];
+  existingFiles?: PortfolioAttachment[];
+};
+
+type FieldName =
+  | "title"
+  | "description"
+  | "content"
+  | "keywords"
+  | "thumbnail"
+  | "videoLink"
+  | "githubLink";
+type FieldErrors = Partial<Record<FieldName, string>>;
+
+const DEFAULT_INITIAL_VALUES: PortfolioFormInitialValues = {
+  title: "",
+  description: "",
+  content: "",
+  videoLink: "",
+  githubLink: "",
+  visibility: "PUBLIC",
+  keywordIds: [],
+};
+
+const sectionTitleClasses =
+  "text-[24px] font-semibold leading-[1.33] tracking-[-0.6px] text-[var(--color-gray-900,#1a1a1a)]";
+
+const formatFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  const kilobytes = bytes / 1024;
+  if (kilobytes < 1024) return `${kilobytes.toFixed(1)} KB`;
+  return `${(kilobytes / 1024).toFixed(1)} MB`;
+};
+
+const isRichTextEmpty = (html: string): boolean =>
+  html
+    .replace(/<[^>]*>/g, "")
+    .replace(/&nbsp;/g, "")
+    .trim().length === 0;
+
+const isValidHttpUrl = (value: string): boolean => {
+  try {
+    const url = new URL(value);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+export const PortfolioForm = ({
+  heading,
+  headingDescription,
+  submitLabel,
+  isSubmitting,
+  submitError,
+  onSubmit,
+  onCancel,
+  initialValues = DEFAULT_INITIAL_VALUES,
+  existingThumbnailUrl = null,
+  existingImages = [],
+  existingFiles = [],
+}: PortfolioFormProps) => {
+  const { keywords, isLoading: isKeywordsLoading } = useKeywords();
+
+  const [title, setTitle] = useState(initialValues.title);
+  const [description, setDescription] = useState(initialValues.description);
+  const [content, setContent] = useState(initialValues.content);
+  const [videoLink, setVideoLink] = useState(initialValues.videoLink);
+  const [githubLink, setGithubLink] = useState(initialValues.githubLink);
+  const [keywordIds, setKeywordIds] = useState<number[]>(initialValues.keywordIds);
+  const [thumbnail, setThumbnail] = useState<File | null>(null);
+  // 편집 모드에서 기존 썸네일을 제거(비움)했는지. true면 existingThumbnailUrl 폴백을 막는다.
+  const [isThumbnailRemoved, setIsThumbnailRemoved] = useState(false);
+  const [images, setImages] = useState<File[]>([]);
+  const [files, setFiles] = useState<File[]>([]);
+  const [removedAttachmentIds, setRemovedAttachmentIds] = useState<number[]>([]);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+
+  // 미리보기 objectURL은 렌더 시 파생하고, cleanup에서만 revoke한다.
+  const newThumbnailPreview = useMemo(
+    () => (thumbnail ? URL.createObjectURL(thumbnail) : null),
+    [thumbnail],
+  );
+  useEffect(() => {
+    if (!newThumbnailPreview) return;
+    return () => URL.revokeObjectURL(newThumbnailPreview);
+  }, [newThumbnailPreview]);
+
+  const imagePreviews = useMemo(() => images.map((image) => URL.createObjectURL(image)), [images]);
+  useEffect(() => {
+    return () => imagePreviews.forEach((url) => URL.revokeObjectURL(url));
+  }, [imagePreviews]);
+
+  // 새 썸네일 > (제거됨 ? 없음 : 기존 썸네일)
+  const thumbnailPreview =
+    newThumbnailPreview ?? (isThumbnailRemoved ? null : existingThumbnailUrl);
+  const hasThumbnail = thumbnail != null || (existingThumbnailUrl != null && !isThumbnailRemoved);
+
+  // 썸네일과 같은 파일인 첨부는 추가 이미지 그리드에서 제외한다.
+  // (여기서 지우면 deleteAttachmentIds로 실제 파일이 삭제돼 썸네일이 404가 된다)
+  const visibleExistingImages = existingImages.filter(
+    (attachment) =>
+      !removedAttachmentIds.includes(attachment.attachmentId) &&
+      attachment.filePath !== existingThumbnailUrl,
+  );
+  const visibleExistingFiles = existingFiles.filter(
+    (attachment) => !removedAttachmentIds.includes(attachment.attachmentId),
+  );
+
+  const selectedKeywords = keywords.filter((keyword) => keywordIds.includes(keyword.keywordId));
+  const availableKeywordOptions = keywords
+    .filter((keyword) => !keywordIds.includes(keyword.keywordId))
+    .map((keyword) => ({ label: keyword.keywordName, value: keyword.keywordId }));
+
+  const handleAddKeyword = (keywordId: number) => {
+    if (!Number.isInteger(keywordId) || keywordIds.includes(keywordId)) return;
+    setKeywordIds((prev) => [...prev, keywordId]);
+  };
+
+  const handleRemoveKeyword = (keywordId: number) => {
+    setKeywordIds((prev) => prev.filter((id) => id !== keywordId));
+  };
+
+  const handleRemoveExistingAttachment = (attachmentId: number) => {
+    setRemovedAttachmentIds((prev) => [...prev, attachmentId]);
+  };
+
+  const handleValidateAndSubmit = () => {
+    const errors: FieldErrors = {};
+
+    const trimmedTitle = title.trim();
+    if (!trimmedTitle) {
+      errors.title = "프로젝트 제목을 입력해주세요.";
+    } else if (trimmedTitle.length > MAX_TITLE_LENGTH) {
+      errors.title = `제목은 ${MAX_TITLE_LENGTH}자 이내로 입력해주세요.`;
+    }
+
+    if (!description.trim()) {
+      errors.description = "간단 설명을 입력해주세요.";
+    }
+
+    if (isRichTextEmpty(content)) {
+      errors.content = "프로젝트 상세 설명을 입력해주세요.";
+    }
+
+    if (keywordIds.length === 0) {
+      errors.keywords = "태그를 1개 이상 선택해주세요.";
+    }
+
+    if (!hasThumbnail) {
+      errors.thumbnail = "썸네일 이미지를 등록해주세요.";
+    }
+
+    const trimmedVideoLink = videoLink.trim();
+    if (trimmedVideoLink && !isValidHttpUrl(trimmedVideoLink)) {
+      errors.videoLink = "올바른 URL 형식이 아닙니다.";
+    }
+
+    const trimmedGithubLink = githubLink.trim();
+    if (trimmedGithubLink && !isValidHttpUrl(trimmedGithubLink)) {
+      errors.githubLink = "올바른 URL 형식이 아닙니다.";
+    }
+
+    setFieldErrors(errors);
+    if (Object.keys(errors).length > 0) return;
+
+    onSubmit({
+      fields: {
+        title: trimmedTitle,
+        description: description.trim() || undefined,
+        content: content || undefined,
+        videoLink: trimmedVideoLink || undefined,
+        githubLink: trimmedGithubLink || undefined,
+        visibility: initialValues.visibility,
+        keywordIds,
+      },
+      thumbnail,
+      images,
+      files,
+      deleteAttachmentIds: removedAttachmentIds,
+    });
+  };
+
+  // 태그 목록 로딩이 끝나기 전에는 폼 대신 공통 로딩 화면을 보여준다(폼 진입 시 태그 준비 완료 보장).
+  if (isKeywordsLoading) {
+    return (
+      <main className="min-h-screen bg-white">
+        <div
+          className="flex items-center justify-center py-40"
+          role="status"
+          aria-label="불러오는 중"
+        >
+          <Spinner size="large" />
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-white">
+      <div className="mx-auto flex max-w-[1440px] flex-col gap-10 px-4 py-12 md:px-8">
+        {/* 헤더 */}
+        <div>
+          <h1 className="mb-2 text-[40px] font-bold leading-[1.3] tracking-[-1px] text-[var(--color-gray-800,#333)]">
+            {heading}
+          </h1>
+          <p className="text-[16px] leading-[1.5] tracking-[-0.4px] text-[var(--color-gray-600,#666)]">
+            {headingDescription}
+          </p>
+        </div>
+
+        {/* 기본 정보 */}
+        <section className="flex flex-col gap-6">
+          <h2 className={sectionTitleClasses}>기본 정보</h2>
+
+          <FormField>
+            <FormLabel htmlFor="portfolio-title" required>
+              프로젝트 제목
+            </FormLabel>
+            <Input
+              id="portfolio-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              placeholder="프로젝트 제목을 입력하세요"
+              maxLength={MAX_TITLE_LENGTH}
+              hasError={Boolean(fieldErrors.title)}
+            />
+            {fieldErrors.title && <FormErrorMessage>{fieldErrors.title}</FormErrorMessage>}
+          </FormField>
+
+          <FormField>
+            <FormLabel htmlFor="portfolio-description" required>
+              간단 설명
+            </FormLabel>
+            <Textarea
+              id="portfolio-description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="프로젝트를 2-3줄로 간단히 요약해주세요"
+              rows={3}
+              maxLength={MAX_DESCRIPTION_LENGTH}
+              hasError={Boolean(fieldErrors.description)}
+              className="min-h-[96px]"
+            />
+            {fieldErrors.description && (
+              <FormErrorMessage>{fieldErrors.description}</FormErrorMessage>
+            )}
+          </FormField>
+
+          <FormField>
+            <FormLabel required>태그</FormLabel>
+            <SelectDropdown
+              isFullWidth
+              placeholder="태그를 선택하세요"
+              options={availableKeywordOptions}
+              onChange={(option) => handleAddKeyword(Number(option.value))}
+            />
+            {selectedKeywords.length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {selectedKeywords.map((keyword) => (
+                  <Tag
+                    key={keyword.keywordId}
+                    onRemove={() => handleRemoveKeyword(keyword.keywordId)}
+                  >
+                    {`#${keyword.keywordName}`}
+                  </Tag>
+                ))}
+              </div>
+            )}
+            {fieldErrors.keywords && <FormErrorMessage>{fieldErrors.keywords}</FormErrorMessage>}
+          </FormField>
+        </section>
+
+        {/* 상세 내용 */}
+        <section className="flex flex-col gap-6">
+          <h2 className={sectionTitleClasses}>상세 내용</h2>
+
+          <FormField>
+            <FormLabel required>프로젝트 상세 설명</FormLabel>
+            <FormHelperText>/ 를 입력하여 다양한 포맷을 사용할 수 있습니다</FormHelperText>
+            <RichEditor
+              content={initialValues.content}
+              onChange={(html) => setContent(html)}
+              placeholder="프로젝트를 자유롭게 소개해주세요"
+              className="min-h-[300px]"
+            />
+            {fieldErrors.content && <FormErrorMessage>{fieldErrors.content}</FormErrorMessage>}
+          </FormField>
+        </section>
+
+        {/* 미디어 및 링크 */}
+        <section className="flex flex-col gap-6">
+          <h2 className={sectionTitleClasses}>미디어 및 링크</h2>
+
+          <FormField>
+            <FormLabel required>썸네일 이미지</FormLabel>
+            <ThumbnailUploader
+              previewUrl={thumbnailPreview ?? undefined}
+              onUpload={(file) => {
+                setThumbnail(file);
+                setIsThumbnailRemoved(false);
+              }}
+              onRemove={() => {
+                // 새로 고른 파일이 있으면 그것만 취소(기존으로 복귀), 없으면 기존 썸네일을 비운다.
+                if (thumbnail) {
+                  setThumbnail(null);
+                } else {
+                  setIsThumbnailRemoved(true);
+                }
+              }}
+            />
+            {fieldErrors.thumbnail && <FormErrorMessage>{fieldErrors.thumbnail}</FormErrorMessage>}
+          </FormField>
+
+          <FormField>
+            <FormLabel>추가 이미지</FormLabel>
+            <FileUploader
+              accept="image/*"
+              multiple
+              onFileSelect={(selected) => setImages((prev) => [...prev, ...selected])}
+            />
+            {(visibleExistingImages.length > 0 || imagePreviews.length > 0) && (
+              <div className="mt-4 grid grid-cols-2 gap-4 md:grid-cols-3">
+                {visibleExistingImages.map((attachment) => (
+                  <div
+                    key={`existing-image-${attachment.attachmentId}`}
+                    className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
+                  >
+                    {/* 서버 이미지 미리보기 (상세 페이지와 동일 방식) */}
+                    <img
+                      src={attachment.filePath}
+                      alt={attachment.originalFilename}
+                      className="h-full w-full object-cover"
+                    />
+                    <Button
+                      variant="danger"
+                      size="small"
+                      className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                      onClick={() => handleRemoveExistingAttachment(attachment.attachmentId)}
+                      aria-label={`${attachment.originalFilename} 삭제`}
+                    >
+                      <XIcon size={16} />
+                    </Button>
+                  </div>
+                ))}
+                {imagePreviews.map((previewUrl, index) => (
+                  <div
+                    key={previewUrl}
+                    className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
+                  >
+                    {/* blob URL 미리보기라 next/image 대신 img 사용 */}
+                    <img
+                      src={previewUrl}
+                      alt={`추가 이미지 ${index + 1}`}
+                      className="h-full w-full object-cover"
+                    />
+                    <Button
+                      variant="danger"
+                      size="small"
+                      className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                      onClick={() => setImages((prev) => prev.filter((_, i) => i !== index))}
+                      aria-label={`추가 이미지 ${index + 1} 삭제`}
+                    >
+                      <XIcon size={16} />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </FormField>
+
+          <FormField>
+            <FormLabel htmlFor="portfolio-video-link">시연 영상 URL</FormLabel>
+            <Input
+              id="portfolio-video-link"
+              type="url"
+              value={videoLink}
+              onChange={(event) => setVideoLink(event.target.value)}
+              placeholder="https://youtube.com/watch?v=..."
+              hasError={Boolean(fieldErrors.videoLink)}
+            />
+            {fieldErrors.videoLink && <FormErrorMessage>{fieldErrors.videoLink}</FormErrorMessage>}
+          </FormField>
+
+          <FormField>
+            <FormLabel htmlFor="portfolio-github-link">GitHub URL</FormLabel>
+            <Input
+              id="portfolio-github-link"
+              type="url"
+              value={githubLink}
+              onChange={(event) => setGithubLink(event.target.value)}
+              placeholder="https://github.com/username/repo"
+              hasError={Boolean(fieldErrors.githubLink)}
+            />
+            {fieldErrors.githubLink && (
+              <FormErrorMessage>{fieldErrors.githubLink}</FormErrorMessage>
+            )}
+          </FormField>
+
+          <FormField>
+            <FormLabel>첨부파일</FormLabel>
+            <FileUploader
+              accept={ATTACHMENT_ACCEPT}
+              multiple
+              onFileSelect={(selected) => setFiles((prev) => [...prev, ...selected])}
+            />
+            {(visibleExistingFiles.length > 0 || files.length > 0) && (
+              <div className="mt-4 flex flex-col gap-2">
+                {visibleExistingFiles.map((attachment) => (
+                  <FileListItem
+                    key={`existing-file-${attachment.attachmentId}`}
+                    file={{
+                      id: `existing-${attachment.attachmentId}`,
+                      name: attachment.originalFilename,
+                      size: formatFileSize(attachment.fileSize),
+                      type: attachment.fileType,
+                    }}
+                    onRemove={() => handleRemoveExistingAttachment(attachment.attachmentId)}
+                  />
+                ))}
+                {files.map((file, index) => (
+                  <FileListItem
+                    key={`${file.name}-${index}`}
+                    file={{
+                      id: String(index),
+                      name: file.name,
+                      size: formatFileSize(file.size),
+                      type: file.type,
+                    }}
+                    onRemove={() => setFiles((prev) => prev.filter((_, i) => i !== index))}
+                  />
+                ))}
+              </div>
+            )}
+          </FormField>
+        </section>
+
+        {/* 제출 */}
+        <div className="flex flex-col gap-3 border-t border-[var(--color-gray-200,#e5e5e5)] pt-6">
+          {submitError && (
+            <FormErrorMessage>저장에 실패했습니다. 잠시 후 다시 시도해주세요.</FormErrorMessage>
+          )}
+          <div className="flex justify-end gap-4">
+            <Button variant="secondary" size="large" onClick={onCancel} disabled={isSubmitting}>
+              취소
+            </Button>
+            <Button
+              variant="primary"
+              size="large"
+              onClick={handleValidateAndSubmit}
+              isLoading={isSubmitting}
+            >
+              {submitLabel}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </main>
+  );
+};

--- a/src/screens/portfolio-form/portfolio-form.tsx
+++ b/src/screens/portfolio-form/portfolio-form.tsx
@@ -9,6 +9,7 @@ import {
   FileUploader,
   ThumbnailUploader,
 } from "@/shared/ui/file-uploader/file-uploader";
+import { Footer } from "@/shared/ui/footer/footer";
 import { FormErrorMessage, FormField, FormHelperText, FormLabel } from "@/shared/ui/form/form";
 import { SelectDropdown } from "@/shared/ui/dropdown";
 import { Input, Textarea } from "@/shared/ui/input/input";
@@ -256,264 +257,271 @@ export const PortfolioForm = ({
   }
 
   return (
-    <main className="min-h-screen bg-white">
-      <div className="mx-auto flex max-w-[1440px] flex-col gap-10 px-4 py-12 md:px-8">
-        {/* 헤더 */}
-        <div>
-          <h1 className="mb-2 text-[40px] font-bold leading-[1.3] tracking-[-1px] text-[var(--color-gray-800,#333)]">
-            {heading}
-          </h1>
-          <p className="text-[16px] leading-[1.5] tracking-[-0.4px] text-[var(--color-gray-600,#666)]">
-            {headingDescription}
-          </p>
-        </div>
+    <div className="flex min-h-screen flex-col bg-white">
+      <main className="flex-1">
+        <div className="mx-auto flex max-w-[1440px] flex-col gap-10 px-4 py-12 md:px-8">
+          {/* 헤더 */}
+          <div>
+            <h1 className="mb-2 text-[40px] font-bold leading-[1.3] tracking-[-1px] text-[var(--color-gray-800,#333)]">
+              {heading}
+            </h1>
+            <p className="text-[16px] leading-[1.5] tracking-[-0.4px] text-[var(--color-gray-600,#666)]">
+              {headingDescription}
+            </p>
+          </div>
 
-        {/* 기본 정보 */}
-        <section className="flex flex-col gap-6">
-          <h2 className={sectionTitleClasses}>기본 정보</h2>
+          {/* 기본 정보 */}
+          <section className="flex flex-col gap-6">
+            <h2 className={sectionTitleClasses}>기본 정보</h2>
 
-          <FormField>
-            <FormLabel htmlFor="portfolio-title" required>
-              프로젝트 제목
-            </FormLabel>
-            <Input
-              id="portfolio-title"
-              value={title}
-              onChange={(event) => setTitle(event.target.value)}
-              placeholder="프로젝트 제목을 입력하세요"
-              maxLength={MAX_TITLE_LENGTH}
-              hasError={Boolean(fieldErrors.title)}
-            />
-            {fieldErrors.title && <FormErrorMessage>{fieldErrors.title}</FormErrorMessage>}
-          </FormField>
+            <FormField>
+              <FormLabel htmlFor="portfolio-title" required>
+                프로젝트 제목
+              </FormLabel>
+              <Input
+                id="portfolio-title"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="프로젝트 제목을 입력하세요"
+                maxLength={MAX_TITLE_LENGTH}
+                hasError={Boolean(fieldErrors.title)}
+              />
+              {fieldErrors.title && <FormErrorMessage>{fieldErrors.title}</FormErrorMessage>}
+            </FormField>
 
-          <FormField>
-            <FormLabel htmlFor="portfolio-description" required>
-              간단 설명
-            </FormLabel>
-            <Textarea
-              id="portfolio-description"
-              value={description}
-              onChange={(event) => setDescription(event.target.value)}
-              placeholder="프로젝트를 2-3줄로 간단히 요약해주세요"
-              rows={3}
-              maxLength={MAX_DESCRIPTION_LENGTH}
-              hasError={Boolean(fieldErrors.description)}
-              className="min-h-[96px]"
-            />
-            {fieldErrors.description && (
-              <FormErrorMessage>{fieldErrors.description}</FormErrorMessage>
-            )}
-          </FormField>
+            <FormField>
+              <FormLabel htmlFor="portfolio-description" required>
+                간단 설명
+              </FormLabel>
+              <Textarea
+                id="portfolio-description"
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                placeholder="프로젝트를 2-3줄로 간단히 요약해주세요"
+                rows={3}
+                maxLength={MAX_DESCRIPTION_LENGTH}
+                hasError={Boolean(fieldErrors.description)}
+                className="min-h-[96px]"
+              />
+              {fieldErrors.description && (
+                <FormErrorMessage>{fieldErrors.description}</FormErrorMessage>
+              )}
+            </FormField>
 
-          <FormField>
-            <FormLabel required>태그</FormLabel>
-            <SelectDropdown
-              isFullWidth
-              placeholder="태그를 선택하세요"
-              options={availableKeywordOptions}
-              onChange={(option) => handleAddKeyword(Number(option.value))}
-            />
-            {selectedKeywords.length > 0 && (
-              <div className="mt-2 flex flex-wrap gap-2">
-                {selectedKeywords.map((keyword) => (
-                  <Tag
-                    key={keyword.keywordId}
-                    onRemove={() => handleRemoveKeyword(keyword.keywordId)}
-                  >
-                    {`#${keyword.keywordName}`}
-                  </Tag>
-                ))}
-              </div>
-            )}
-            {fieldErrors.keywords && <FormErrorMessage>{fieldErrors.keywords}</FormErrorMessage>}
-          </FormField>
-        </section>
-
-        {/* 상세 내용 */}
-        <section className="flex flex-col gap-6">
-          <h2 className={sectionTitleClasses}>상세 내용</h2>
-
-          <FormField>
-            <FormLabel required>프로젝트 상세 설명</FormLabel>
-            <FormHelperText>/ 를 입력하여 다양한 포맷을 사용할 수 있습니다</FormHelperText>
-            <RichEditor
-              content={initialValues.content}
-              onChange={(html) => setContent(html)}
-              placeholder="프로젝트를 자유롭게 소개해주세요"
-              className="min-h-[300px]"
-            />
-            {fieldErrors.content && <FormErrorMessage>{fieldErrors.content}</FormErrorMessage>}
-          </FormField>
-        </section>
-
-        {/* 미디어 및 링크 */}
-        <section className="flex flex-col gap-6">
-          <h2 className={sectionTitleClasses}>미디어 및 링크</h2>
-
-          <FormField>
-            <FormLabel required>썸네일 이미지</FormLabel>
-            <ThumbnailUploader
-              previewUrl={thumbnailPreview ?? undefined}
-              onUpload={(file) => {
-                setThumbnail(file);
-                setIsThumbnailRemoved(false);
-              }}
-              onRemove={() => {
-                // 새로 고른 파일이 있으면 그것만 취소(기존으로 복귀), 없으면 기존 썸네일을 비운다.
-                if (thumbnail) {
-                  setThumbnail(null);
-                } else {
-                  setIsThumbnailRemoved(true);
-                }
-              }}
-            />
-            {fieldErrors.thumbnail && <FormErrorMessage>{fieldErrors.thumbnail}</FormErrorMessage>}
-          </FormField>
-
-          <FormField>
-            <FormLabel>추가 이미지</FormLabel>
-            <FileUploader
-              accept="image/*"
-              multiple
-              onFileSelect={(selected) => setImages((prev) => [...prev, ...selected])}
-            />
-            {(visibleExistingImages.length > 0 || imagePreviews.length > 0) && (
-              <div className="mt-4 grid grid-cols-2 gap-4 md:grid-cols-3">
-                {visibleExistingImages.map((attachment) => (
-                  <div
-                    key={`existing-image-${attachment.attachmentId}`}
-                    className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
-                  >
-                    {/* 서버 이미지 미리보기 (상세 페이지와 동일 방식) */}
-                    <img
-                      src={attachment.filePath}
-                      alt={attachment.originalFilename}
-                      className="h-full w-full object-cover"
-                    />
-                    <Button
-                      variant="danger"
-                      size="small"
-                      className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
-                      onClick={() => handleRemoveExistingAttachment(attachment.attachmentId)}
-                      aria-label={`${attachment.originalFilename} 삭제`}
+            <FormField>
+              <FormLabel required>태그</FormLabel>
+              <SelectDropdown
+                isFullWidth
+                placeholder="태그를 선택하세요"
+                options={availableKeywordOptions}
+                onChange={(option) => handleAddKeyword(Number(option.value))}
+              />
+              {selectedKeywords.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {selectedKeywords.map((keyword) => (
+                    <Tag
+                      key={keyword.keywordId}
+                      onRemove={() => handleRemoveKeyword(keyword.keywordId)}
                     >
-                      <XIcon size={16} />
-                    </Button>
-                  </div>
-                ))}
-                {imagePreviews.map((previewUrl, index) => (
-                  <div
-                    key={previewUrl}
-                    className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
-                  >
-                    {/* blob URL 미리보기라 next/image 대신 img 사용 */}
-                    <img
-                      src={previewUrl}
-                      alt={`추가 이미지 ${index + 1}`}
-                      className="h-full w-full object-cover"
-                    />
-                    <Button
-                      variant="danger"
-                      size="small"
-                      className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
-                      onClick={() => setImages((prev) => prev.filter((_, i) => i !== index))}
-                      aria-label={`추가 이미지 ${index + 1} 삭제`}
+                      {`#${keyword.keywordName}`}
+                    </Tag>
+                  ))}
+                </div>
+              )}
+              {fieldErrors.keywords && <FormErrorMessage>{fieldErrors.keywords}</FormErrorMessage>}
+            </FormField>
+          </section>
+
+          {/* 상세 내용 */}
+          <section className="flex flex-col gap-6">
+            <h2 className={sectionTitleClasses}>상세 내용</h2>
+
+            <FormField>
+              <FormLabel required>프로젝트 상세 설명</FormLabel>
+              <FormHelperText>/ 를 입력하여 다양한 포맷을 사용할 수 있습니다</FormHelperText>
+              <RichEditor
+                content={initialValues.content}
+                onChange={(html) => setContent(html)}
+                placeholder="프로젝트를 자유롭게 소개해주세요"
+                className="min-h-[300px]"
+              />
+              {fieldErrors.content && <FormErrorMessage>{fieldErrors.content}</FormErrorMessage>}
+            </FormField>
+          </section>
+
+          {/* 미디어 및 링크 */}
+          <section className="flex flex-col gap-6">
+            <h2 className={sectionTitleClasses}>미디어 및 링크</h2>
+
+            <FormField>
+              <FormLabel required>썸네일 이미지</FormLabel>
+              <ThumbnailUploader
+                previewUrl={thumbnailPreview ?? undefined}
+                onUpload={(file) => {
+                  setThumbnail(file);
+                  setIsThumbnailRemoved(false);
+                }}
+                onRemove={() => {
+                  // 새로 고른 파일이 있으면 그것만 취소(기존으로 복귀), 없으면 기존 썸네일을 비운다.
+                  if (thumbnail) {
+                    setThumbnail(null);
+                  } else {
+                    setIsThumbnailRemoved(true);
+                  }
+                }}
+              />
+              {fieldErrors.thumbnail && (
+                <FormErrorMessage>{fieldErrors.thumbnail}</FormErrorMessage>
+              )}
+            </FormField>
+
+            <FormField>
+              <FormLabel>추가 이미지</FormLabel>
+              <FileUploader
+                accept="image/*"
+                multiple
+                onFileSelect={(selected) => setImages((prev) => [...prev, ...selected])}
+              />
+              {(visibleExistingImages.length > 0 || imagePreviews.length > 0) && (
+                <div className="mt-4 grid grid-cols-2 gap-4 md:grid-cols-3">
+                  {visibleExistingImages.map((attachment) => (
+                    <div
+                      key={`existing-image-${attachment.attachmentId}`}
+                      className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
                     >
-                      <XIcon size={16} />
-                    </Button>
-                  </div>
-                ))}
-              </div>
+                      {/* 서버 이미지 미리보기 (상세 페이지와 동일 방식) */}
+                      <img
+                        src={attachment.filePath}
+                        alt={attachment.originalFilename}
+                        className="h-full w-full object-cover"
+                      />
+                      <Button
+                        variant="danger"
+                        size="small"
+                        className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                        onClick={() => handleRemoveExistingAttachment(attachment.attachmentId)}
+                        aria-label={`${attachment.originalFilename} 삭제`}
+                      >
+                        <XIcon size={16} />
+                      </Button>
+                    </div>
+                  ))}
+                  {imagePreviews.map((previewUrl, index) => (
+                    <div
+                      key={previewUrl}
+                      className="group relative aspect-video overflow-hidden rounded-lg border border-[var(--color-gray-200,#e5e5e5)]"
+                    >
+                      {/* blob URL 미리보기라 next/image 대신 img 사용 */}
+                      <img
+                        src={previewUrl}
+                        alt={`추가 이미지 ${index + 1}`}
+                        className="h-full w-full object-cover"
+                      />
+                      <Button
+                        variant="danger"
+                        size="small"
+                        className="absolute right-2 top-2 h-8 w-8 p-0 opacity-0 transition-opacity group-hover:opacity-100"
+                        onClick={() => setImages((prev) => prev.filter((_, i) => i !== index))}
+                        aria-label={`추가 이미지 ${index + 1} 삭제`}
+                      >
+                        <XIcon size={16} />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </FormField>
+
+            <FormField>
+              <FormLabel htmlFor="portfolio-video-link">시연 영상 URL</FormLabel>
+              <Input
+                id="portfolio-video-link"
+                type="url"
+                value={videoLink}
+                onChange={(event) => setVideoLink(event.target.value)}
+                placeholder="https://youtube.com/watch?v=..."
+                hasError={Boolean(fieldErrors.videoLink)}
+              />
+              {fieldErrors.videoLink && (
+                <FormErrorMessage>{fieldErrors.videoLink}</FormErrorMessage>
+              )}
+            </FormField>
+
+            <FormField>
+              <FormLabel htmlFor="portfolio-github-link">GitHub URL</FormLabel>
+              <Input
+                id="portfolio-github-link"
+                type="url"
+                value={githubLink}
+                onChange={(event) => setGithubLink(event.target.value)}
+                placeholder="https://github.com/username/repo"
+                hasError={Boolean(fieldErrors.githubLink)}
+              />
+              {fieldErrors.githubLink && (
+                <FormErrorMessage>{fieldErrors.githubLink}</FormErrorMessage>
+              )}
+            </FormField>
+
+            <FormField>
+              <FormLabel>첨부파일</FormLabel>
+              <FileUploader
+                accept={ATTACHMENT_ACCEPT}
+                multiple
+                onFileSelect={(selected) => setFiles((prev) => [...prev, ...selected])}
+              />
+              {(visibleExistingFiles.length > 0 || files.length > 0) && (
+                <div className="mt-4 flex flex-col gap-2">
+                  {visibleExistingFiles.map((attachment) => (
+                    <FileListItem
+                      key={`existing-file-${attachment.attachmentId}`}
+                      file={{
+                        id: `existing-${attachment.attachmentId}`,
+                        name: attachment.originalFilename,
+                        size: formatFileSize(attachment.fileSize),
+                        type: attachment.fileType,
+                      }}
+                      onRemove={() => handleRemoveExistingAttachment(attachment.attachmentId)}
+                    />
+                  ))}
+                  {files.map((file, index) => (
+                    <FileListItem
+                      key={`${file.name}-${index}`}
+                      file={{
+                        id: String(index),
+                        name: file.name,
+                        size: formatFileSize(file.size),
+                        type: file.type,
+                      }}
+                      onRemove={() => setFiles((prev) => prev.filter((_, i) => i !== index))}
+                    />
+                  ))}
+                </div>
+              )}
+            </FormField>
+          </section>
+
+          {/* 제출 */}
+          <div className="flex flex-col gap-3 border-t border-[var(--color-gray-200,#e5e5e5)] pt-6">
+            {submitError && (
+              <FormErrorMessage>저장에 실패했습니다. 잠시 후 다시 시도해주세요.</FormErrorMessage>
             )}
-          </FormField>
-
-          <FormField>
-            <FormLabel htmlFor="portfolio-video-link">시연 영상 URL</FormLabel>
-            <Input
-              id="portfolio-video-link"
-              type="url"
-              value={videoLink}
-              onChange={(event) => setVideoLink(event.target.value)}
-              placeholder="https://youtube.com/watch?v=..."
-              hasError={Boolean(fieldErrors.videoLink)}
-            />
-            {fieldErrors.videoLink && <FormErrorMessage>{fieldErrors.videoLink}</FormErrorMessage>}
-          </FormField>
-
-          <FormField>
-            <FormLabel htmlFor="portfolio-github-link">GitHub URL</FormLabel>
-            <Input
-              id="portfolio-github-link"
-              type="url"
-              value={githubLink}
-              onChange={(event) => setGithubLink(event.target.value)}
-              placeholder="https://github.com/username/repo"
-              hasError={Boolean(fieldErrors.githubLink)}
-            />
-            {fieldErrors.githubLink && (
-              <FormErrorMessage>{fieldErrors.githubLink}</FormErrorMessage>
-            )}
-          </FormField>
-
-          <FormField>
-            <FormLabel>첨부파일</FormLabel>
-            <FileUploader
-              accept={ATTACHMENT_ACCEPT}
-              multiple
-              onFileSelect={(selected) => setFiles((prev) => [...prev, ...selected])}
-            />
-            {(visibleExistingFiles.length > 0 || files.length > 0) && (
-              <div className="mt-4 flex flex-col gap-2">
-                {visibleExistingFiles.map((attachment) => (
-                  <FileListItem
-                    key={`existing-file-${attachment.attachmentId}`}
-                    file={{
-                      id: `existing-${attachment.attachmentId}`,
-                      name: attachment.originalFilename,
-                      size: formatFileSize(attachment.fileSize),
-                      type: attachment.fileType,
-                    }}
-                    onRemove={() => handleRemoveExistingAttachment(attachment.attachmentId)}
-                  />
-                ))}
-                {files.map((file, index) => (
-                  <FileListItem
-                    key={`${file.name}-${index}`}
-                    file={{
-                      id: String(index),
-                      name: file.name,
-                      size: formatFileSize(file.size),
-                      type: file.type,
-                    }}
-                    onRemove={() => setFiles((prev) => prev.filter((_, i) => i !== index))}
-                  />
-                ))}
-              </div>
-            )}
-          </FormField>
-        </section>
-
-        {/* 제출 */}
-        <div className="flex flex-col gap-3 border-t border-[var(--color-gray-200,#e5e5e5)] pt-6">
-          {submitError && (
-            <FormErrorMessage>저장에 실패했습니다. 잠시 후 다시 시도해주세요.</FormErrorMessage>
-          )}
-          <div className="flex justify-end gap-4">
-            <Button variant="secondary" size="large" onClick={onCancel} disabled={isSubmitting}>
-              취소
-            </Button>
-            <Button
-              variant="primary"
-              size="large"
-              onClick={handleValidateAndSubmit}
-              isLoading={isSubmitting}
-            >
-              {submitLabel}
-            </Button>
+            <div className="flex justify-end gap-4">
+              <Button variant="secondary" size="large" onClick={onCancel} disabled={isSubmitting}>
+                취소
+              </Button>
+              <Button
+                variant="primary"
+                size="large"
+                onClick={handleValidateAndSubmit}
+                isLoading={isSubmitting}
+              >
+                {submitLabel}
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
-    </main>
+      </main>
+      <Footer className="mt-auto" />
+    </div>
   );
 };

--- a/src/screens/portfolio/portfolio-list.tsx
+++ b/src/screens/portfolio/portfolio-list.tsx
@@ -27,7 +27,9 @@ const formatPortfolioDate = (iso: string): string => {
 const toCardTags = (item: PortfolioListItem): string[] =>
   item.keywords.map((keyword) => `#${keyword.keywordName}`);
 
-const toAuthorLabel = (item: PortfolioListItem): string => `사용자 ${item.userId}`;
+// 작성자 이름(authorName)을 표시하고, 비어있으면 사용자 ID로 폴백한다.
+const toAuthorLabel = (item: PortfolioListItem): string =>
+  item.authorName?.trim() || `사용자 ${item.userId}`;
 
 const PortfolioCardSkeleton = () => (
   <div

--- a/src/screens/portfolio/portfolio-page-header.tsx
+++ b/src/screens/portfolio/portfolio-page-header.tsx
@@ -1,6 +1,9 @@
 "use client";
 
+import Link from "next/link";
 import type { PortfolioSort } from "@/api/posts";
+import { useAuthReady } from "@/lib/auth";
+import { PlusIcon } from "@/shared/ui/icons";
 
 export type PortfolioPageHeaderProps = {
   totalCount: number;
@@ -39,12 +42,17 @@ const sortButtonInactiveClasses =
 const getSortButtonClasses = (isActive: boolean): string =>
   [sortButtonBaseClasses, isActive ? sortButtonActiveClasses : sortButtonInactiveClasses].join(" ");
 
+const createButtonClasses =
+  "inline-flex h-10 items-center gap-2 rounded-lg bg-[var(--color-primary-800,#004a9c)] px-6 text-[14px] font-medium text-white transition-colors hover:bg-[var(--color-primary-900,#003876)]";
+
 export const PortfolioPageHeader = ({
   totalCount,
   sort,
   onSortChange,
   keyword,
 }: PortfolioPageHeaderProps) => {
+  const { isAuthenticated } = useAuthReady();
+
   return (
     <div className="space-y-6">
       <div className="flex items-end justify-between">
@@ -56,19 +64,28 @@ export const PortfolioPageHeader = ({
         </p>
       </div>
 
-      <div className="flex items-center gap-3">
-        {portfolioSortOptions.map((option) => (
-          <button
-            key={option.value}
-            type="button"
-            onClick={() => onSortChange(option.value)}
-            className={getSortButtonClasses(sort === option.value)}
-            aria-pressed={sort === option.value}
-            aria-label={`${option.label}으로 정렬`}
-          >
-            {option.label}
-          </button>
-        ))}
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-3">
+          {portfolioSortOptions.map((option) => (
+            <button
+              key={option.value}
+              type="button"
+              onClick={() => onSortChange(option.value)}
+              className={getSortButtonClasses(sort === option.value)}
+              aria-pressed={sort === option.value}
+              aria-label={`${option.label}으로 정렬`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+
+        {isAuthenticated && (
+          <Link href="/portfolio/create" className={createButtonClasses}>
+            <PlusIcon size={18} />
+            포트폴리오 작성
+          </Link>
+        )}
       </div>
     </div>
   );

--- a/src/screens/portfolio/portfolio-page.tsx
+++ b/src/screens/portfolio/portfolio-page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import {
   getPortfolioList,
@@ -10,7 +10,7 @@ import {
   type PortfolioSort,
 } from "@/api/posts";
 import { useAuthReady } from "@/lib/auth";
-import { Pagination } from "@/shared/ui";
+import { Footer, Pagination } from "@/shared/ui";
 import { PortfolioList } from "./portfolio-list";
 import { PortfolioPageHeader } from "./portfolio-page-header";
 import { PortfolioSearchBar } from "./portfolio-search-bar";
@@ -42,7 +42,7 @@ export const PortfolioListPage = () => {
   const { isReady: isAuthReady } = useAuthReady();
   const urlKeyword = searchParams.get("keyword") ?? "";
   const keyword = urlKeyword.trim();
-  const lastKeywordRef = useRef(keyword);
+  const [lastKeyword, setLastKeyword] = useState(keyword);
   const [query, setQuery] = useState<PortfolioQuery>({
     page: 1,
     sort: "LATEST",
@@ -50,18 +50,19 @@ export const PortfolioListPage = () => {
   });
   const [result, setResult] = useState<PortfolioFetchResult | null>(null);
 
-  const effectiveQuery = lastKeywordRef.current === keyword ? query : { ...query, page: 1 };
+  // keyword가 바뀐 렌더에서 즉시 page를 1로 반영한다(ref 대신 state로 렌더 중 조정 — React 권장 패턴).
+  if (lastKeyword !== keyword) {
+    setLastKeyword(keyword);
+    setQuery((previous) => (previous.page === 1 ? previous : { ...previous, page: 1 }));
+  }
+
+  const effectiveQuery = lastKeyword === keyword ? query : { ...query, page: 1 };
   const queryKey = toPortfolioQueryKey(effectiveQuery, keyword);
   const hasMatchingResult = result?.queryKey === queryKey;
   // 비로그인도 조회 가능. 인증 상태가 확정(isReady)되면 조회한다.
   const isLoading = !isAuthReady || !hasMatchingResult;
   const data = hasMatchingResult ? result.data : undefined;
   const error = hasMatchingResult ? (result.error ?? null) : null;
-
-  useEffect(() => {
-    lastKeywordRef.current = keyword;
-    setQuery((previous) => (previous.page === 1 ? previous : { ...previous, page: 1 }));
-  }, [keyword]);
 
   useEffect(() => {
     if (!isAuthReady) return;
@@ -133,42 +134,45 @@ export const PortfolioListPage = () => {
   const totalPages = data?.totalPages ?? 0;
 
   return (
-    <main className="min-h-screen bg-white">
-      <div className="mx-auto max-w-[1440px] px-4 py-16">
-        <div className="mb-8">
-          <PortfolioSearchBar initialKeyword={keyword} onSubmit={handleSearchSubmit} />
+    <div className="flex min-h-screen flex-col bg-white">
+      <main className="flex-1">
+        <div className="mx-auto max-w-[1440px] px-4 py-16">
+          <div className="mb-8">
+            <PortfolioSearchBar initialKeyword={keyword} onSubmit={handleSearchSubmit} />
+          </div>
+
+          <div className="mb-8">
+            <PortfolioTypeFilter selectedTypes={query.selectedTypes} onChange={handleTypesChange} />
+          </div>
+
+          <div className="space-y-8">
+            <PortfolioPageHeader
+              totalCount={totalElements}
+              sort={query.sort}
+              onSortChange={handleSortChange}
+              keyword={keyword}
+            />
+
+            <PortfolioList
+              portfolios={data?.content ?? []}
+              isLoading={isLoading}
+              error={error}
+              hasKeyword={Boolean(keyword)}
+            />
+
+            {!isLoading && !error && totalPages > 1 && (
+              <div className="flex justify-center pt-8">
+                <Pagination
+                  currentPage={query.page}
+                  totalPages={totalPages}
+                  onPageChange={handlePageChange}
+                />
+              </div>
+            )}
+          </div>
         </div>
-
-        <div className="mb-8">
-          <PortfolioTypeFilter selectedTypes={query.selectedTypes} onChange={handleTypesChange} />
-        </div>
-
-        <div className="space-y-8">
-          <PortfolioPageHeader
-            totalCount={totalElements}
-            sort={query.sort}
-            onSortChange={handleSortChange}
-            keyword={keyword}
-          />
-
-          <PortfolioList
-            portfolios={data?.content ?? []}
-            isLoading={isLoading}
-            error={error}
-            hasKeyword={Boolean(keyword)}
-          />
-
-          {!isLoading && !error && totalPages > 1 && (
-            <div className="flex justify-center pt-8">
-              <Pagination
-                currentPage={query.page}
-                totalPages={totalPages}
-                onPageChange={handlePageChange}
-              />
-            </div>
-          )}
-        </div>
-      </div>
-    </main>
+      </main>
+      <Footer className="mt-auto" />
+    </div>
   );
 };

--- a/src/shared/ui/file-uploader/file-uploader.tsx
+++ b/src/shared/ui/file-uploader/file-uploader.tsx
@@ -130,10 +130,7 @@ export const ThumbnailUploader = ({
         onChange={handleFileChange}
       />
       <div className="text-center pointer-events-none">
-        <ImageIcon
-          size={48}
-          className="mx-auto mb-3 text-[var(--color-gray-400,#999)] group-hover:text-[var(--color-primary-500)] transition-colors"
-        />
+        <ImageIcon size={48} className="mx-auto mb-3 text-[var(--color-gray-400,#999)]" />
         <p className="text-[16px] font-medium text-[var(--color-gray-800,#333)]">
           썸네일 이미지 업로드
         </p>

--- a/src/shared/ui/footer/footer.tsx
+++ b/src/shared/ui/footer/footer.tsx
@@ -1,8 +1,6 @@
-import Image from "next/image";
 import Link from "next/link";
 import { storageAsset } from "@/shared/config/storage-asset";
 
-// --- Types ---
 export type FooterLink = {
   label: string;
   href: string;
@@ -16,24 +14,6 @@ export type FooterProps = {
   className?: string;
 };
 
-// --- Styles ---
-const footerBaseClasses =
-  "w-full bg-[color:var(--color-gray-50,#f9f9f9)] border-t border-[color:var(--color-gray-200,#e5e5ec)]";
-
-const getFooterClasses = (className?: string) =>
-  [footerBaseClasses, className].filter(Boolean).join(" ");
-
-const contentClasses = "mx-auto max-w-[1440px] py-5";
-
-const infoTextClasses =
-  "text-[14px] leading-[1.6] tracking-[-0.35px] text-[color:var(--color-gray-500,#808080)]";
-
-const linkClasses =
-  "underline text-[14px] font-bold leading-[1.6] tracking-[-0.35px] text-[color:var(--color-gray-500,#808080)] hover:text-[color:var(--color-gray-700,#666)] transition-colors";
-
-const copyrightClasses = "text-[12px] leading-[1.6] text-[color:var(--color-gray-400,#b3b3b3)]";
-
-// --- Default Values ---
 const DEFAULT_LINKS: FooterLink[] = [
   { label: "이용약관", href: "/terms" },
   { label: "개인정보처리방침", href: "/privacy" },
@@ -42,9 +22,56 @@ const DEFAULT_LINKS: FooterLink[] = [
 
 const DEFAULT_ADDRESS = "16499 경기도 수원시 영통구 월드컵로 206 아주대학교";
 const DEFAULT_PHONE = "T. 031-219-2114";
-const DEFAULT_COPYRIGHT = "© 2025 AJOU University. All rights reserved.";
+const DEFAULT_COPYRIGHT = "Copyright © 2024 Ajou University. All Rights Reserved.";
 
-// --- Component ---
+const InstagramIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <rect x="2" y="2" width="20" height="20" rx="5" ry="5" />
+    <path d="M16 11.37A4 4 0 1 1 12.63 8 4 4 0 0 1 16 11.37z" />
+    <line x1="17.5" y1="6.5" x2="17.51" y2="6.5" />
+  </svg>
+);
+
+const FacebookIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M18 2h-3a5 5 0 0 0-5 5v3H7v4h3v8h4v-8h3l1-4h-4V7a1 1 0 0 1 1-1h3z" />
+  </svg>
+);
+
+const YoutubeIcon = () => (
+  <svg
+    width="24"
+    height="24"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="1.5"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+  >
+    <path d="M22.54 6.42a2.78 2.78 0 0 0-1.95-1.96C18.88 4 12 4 12 4s-6.88 0-8.59.46A2.78 2.78 0 0 0 1.46 6.42 29 29 0 0 0 1 12a29 29 0 0 0 .46 5.58 2.78 2.78 0 0 0 1.95 1.96C5.12 20 12 20 12 20s6.88 0 8.59-.46a2.78 2.78 0 0 0 1.95-1.96A29 29 0 0 0 23 12a29 29 0 0 0-.46-5.58z" />
+    <polygon points="9.75 15.02 15.5 12 9.75 8.98 9.75 15.02" />
+  </svg>
+);
+
 export const Footer = ({
   links = DEFAULT_LINKS,
   address = DEFAULT_ADDRESS,
@@ -52,42 +79,78 @@ export const Footer = ({
   copyright = DEFAULT_COPYRIGHT,
   className,
 }: FooterProps) => {
-  const footerClasses = getFooterClasses(className);
-
   return (
-    <footer className={footerClasses}>
-      <div className={contentClasses}>
-        <div className="flex items-end justify-between gap-6 flex-col sm:flex-row">
+    <footer
+      className={["w-full bg-[#f9f9f9] border-t border-[#e5e5e5]", className]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <div className="mx-auto flex h-50 max-w-360 items-center">
+        <div className="flex w-full items-end justify-between gap-5">
           {/* Left: Logo + Info */}
-          <div className="flex items-center gap-10 flex-col sm:flex-row">
+          <div className="flex items-center gap-10">
             {/* Ajou Logo */}
-            <div className="relative shrink-0 h-15 w-58">
-              <Image
-                src={storageAsset("ajou-logo-text.svg")}
-                alt="Ajou University Logo"
-                fill
-                className="object-contain"
-              />
-            </div>
+            <img
+              src={storageAsset("ajou-logo-text.svg")}
+              alt="Ajou University"
+              className="h-15 w-58 shrink-0 object-contain"
+            />
 
             {/* Info */}
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-5">
               {/* Policy Links */}
               <div className="flex items-center gap-4 flex-wrap">
                 {links.map((link) => (
-                  <Link key={link.href} href={link.href} className={linkClasses}>
+                  <Link
+                    key={link.href}
+                    href={link.href}
+                    className="underline text-[16px] leading-normal tracking-[-0.4px] text-[#808080] hover:text-[#555] transition-colors"
+                  >
                     {link.label}
                   </Link>
                 ))}
               </div>
 
               {/* Address & Copyright */}
-              <div className={infoTextClasses}>
-                <p>{address}</p>
-                <p>{phone}</p>
-                <p className={copyrightClasses}>{copyright}</p>
-              </div>
+              <p className="text-[16px] leading-normal tracking-[-0.4px] text-[#808080] whitespace-nowrap">
+                {address}
+                <br />
+                {phone}
+                <br />
+                {copyright}
+              </p>
             </div>
+          </div>
+
+          {/* Right: Social Icons */}
+          <div className="flex items-center gap-3 shrink-0">
+            <a
+              href="https://instagram.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="인스타그램"
+              className="text-[#808080] hover:text-[#555] transition-colors"
+            >
+              <InstagramIcon />
+            </a>
+            <a
+              href="https://facebook.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="페이스북"
+              className="text-[#808080] hover:text-[#555] transition-colors"
+            >
+              <FacebookIcon />
+            </a>
+            <a
+              href="https://youtube.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="유튜브"
+              className="text-[#808080] hover:text-[#555] transition-colors"
+            >
+              <YoutubeIcon />
+            </a>
           </div>
         </div>
       </div>

--- a/src/shared/ui/index.ts
+++ b/src/shared/ui/index.ts
@@ -8,6 +8,8 @@ export { Navigation } from "./navigation/navigation";
 export type { NavigationProps, NavItem, NavUser } from "./navigation/navigation";
 export { Footer } from "./footer/footer";
 export type { FooterProps, FooterLink } from "./footer/footer";
+export { Loading } from "./loading";
+export type { LoadingProps, LoadingSize } from "./loading";
 
 // Form components
 export * from "./form";

--- a/src/shared/ui/loading/index.ts
+++ b/src/shared/ui/loading/index.ts
@@ -1,0 +1,2 @@
+export { Loading } from "./loading";
+export type { LoadingProps, LoadingSize } from "./loading";

--- a/src/shared/ui/loading/loading.stories.tsx
+++ b/src/shared/ui/loading/loading.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/nextjs";
+import { Loading } from "./loading";
+
+const meta = {
+  title: "Shared/UI/Loading",
+  component: Loading,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["small", "medium", "large"],
+    },
+    isFullScreen: {
+      control: "boolean",
+    },
+  },
+} satisfies Meta<typeof Loading>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    text: "불러오는 중...",
+    size: "medium",
+  },
+};
+
+export const PortfolioSearch: Story = {
+  args: {
+    text: "최적의 포트폴리오를 찾는 중...",
+    size: "medium",
+  },
+};
+
+export const DotsOnly: Story = {
+  args: {
+    size: "medium",
+  },
+};
+
+export const Small: Story = {
+  args: {
+    text: "불러오는 중...",
+    size: "small",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    text: "최적의 포트폴리오를 찾는 중...",
+    size: "large",
+  },
+};
+
+export const FullScreen: Story = {
+  args: {
+    text: "페이지를 불러오는 중...",
+    size: "large",
+    isFullScreen: true,
+  },
+  parameters: {
+    layout: "fullscreen",
+  },
+};

--- a/src/shared/ui/loading/loading.tsx
+++ b/src/shared/ui/loading/loading.tsx
@@ -1,0 +1,121 @@
+export type LoadingSize = "small" | "medium" | "large";
+
+export interface LoadingProps {
+  /** 로딩 중 표시할 문구 (페이지마다 다르게 주입). 없으면 점만 표시 */
+  text?: string;
+  size?: LoadingSize;
+  /** 전체 화면 오버레이로 표시 (페이지 이동 시 사용) */
+  isFullScreen?: boolean;
+  className?: string;
+}
+
+// 점마다 아주 블루 팔레트를 진 → 연으로 (물결 색상 그라데이션). 밝은 배경(인라인)용
+const dotColorClasses = [
+  "bg-[color:var(--color-primary-800,#004A9C)]",
+  "bg-[color:var(--color-primary-600,#0066CC)]",
+  "bg-[color:var(--color-primary-400,#5C9DE5)]",
+] as const;
+
+// 전체 화면은 진한 블루 아치 위에 얹히므로, 점도 밝은 톤(흰색 → 하늘색)으로 뒤집는다
+const dotColorClassesOnCover = [
+  "bg-white",
+  "bg-[color:var(--color-primary-100,#E0EDFB)]",
+  "bg-[color:var(--color-primary-300,#85B5EE)]",
+] as const;
+
+const dotSizeClasses: Record<LoadingSize, string> = {
+  small: "h-1.5 w-1.5",
+  medium: "h-2.5 w-2.5",
+  large: "h-3.5 w-3.5",
+};
+
+const gapClasses: Record<LoadingSize, string> = {
+  small: "gap-1",
+  medium: "gap-1.5",
+  large: "gap-2",
+};
+
+const textSizeClasses: Record<LoadingSize, string> = {
+  small: "text-[12px] leading-[16px]",
+  medium: "text-[14px] leading-[20px]",
+  large: "text-[16px] leading-[24px]",
+};
+
+// 전체 화면에서 화면을 덮는 솔리드의 색(SVG path fill). 색만 바꾸려면 여기만 수정하면 된다.
+const coverPanelColor = "var(--color-primary-800,#004A9C)";
+
+// 전체 화면에서는 진한 블루 판 위에 글자가 얹히므로, 회색 대신 흰색으로 대비를 확보한다
+const getTextClasses = (size: LoadingSize, isFullScreen: boolean) =>
+  [
+    isFullScreen
+      ? "font-semibold text-white"
+      : "font-medium text-[color:var(--color-gray-700,#4D4D4D)]",
+    textSizeClasses[size],
+  ].join(" ");
+
+export const Loading = ({
+  text,
+  size = "medium",
+  isFullScreen = false,
+  className = "",
+}: LoadingProps) => {
+  const containerClasses = isFullScreen
+    ? "fixed inset-0 z-[var(--z-modal,1050)] flex items-center justify-center overflow-hidden"
+    : "inline-flex items-center justify-center";
+
+  // 아치 솔리드는 z-0, 문구·점은 z-10 → 덮개가 항상 콘텐츠 뒤에 깔린다
+  const contentClasses = [
+    "relative flex flex-col items-center justify-center gap-3",
+    isFullScreen ? "z-10 animate-loading-content-in" : "",
+    className,
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  const dotsWrapperClasses = ["flex items-end", gapClasses[size]].join(" ");
+
+  const dotBaseClasses = [
+    "inline-block rounded-full animate-wave-bounce",
+    dotSizeClasses[size],
+  ].join(" ");
+
+  const dots = isFullScreen ? dotColorClassesOnCover : dotColorClasses;
+
+  return (
+    <div className={containerClasses} role="status" aria-live="polite" aria-busy="true">
+      {isFullScreen && (
+        // 솔리드가 아래에서 한 번 올라와 이전 화면을 덮는다 (반복 없음).
+        // 윗변은 SVG 2차 베지어 — 가운데 컨트롤 포인트를 당겨 곡률을 만들었다가 마지막에 편다.
+        <div className="loading-panel animate-panel-cover z-0" aria-hidden="true">
+          <svg className="loading-panel-svg" viewBox="0 0 100 100" preserveAspectRatio="none">
+            <path
+              className="loading-panel-fill"
+              fill={coverPanelColor}
+              d="M 0 0 Q 50 0 100 0 L 100 100 L 0 100 Z"
+            />
+          </svg>
+        </div>
+      )}
+
+      <div className={contentClasses}>
+        {text && <p className={getTextClasses(size, isFullScreen)}>{text}</p>}
+
+        <div className={dotsWrapperClasses} aria-hidden="true">
+          {dots.map((colorClass, index) => (
+            <span
+              key={index}
+              className={`${dotBaseClasses} ${colorClass}`}
+              // 0.15s씩 순차 지연 → 물결 파동 (인라인 스타일이 shorthand animation 을 확실히 덮어씀)
+              style={{ animationDelay: `${index * 0.15}s` }}
+            />
+          ))}
+        </div>
+
+        {/* text 가 없을 때 스크린리더용 대체 문구 */}
+        {!text && <span className="sr-only">불러오는 중</span>}
+      </div>
+    </div>
+  );
+};
+
+Loading.displayName = "Loading";

--- a/src/shared/ui/rich-editor/rich-editor.tsx
+++ b/src/shared/ui/rich-editor/rich-editor.tsx
@@ -103,9 +103,13 @@ const slashCommandItems: SlashCommandItem[] = [
     searchTerms: ["image", "img", "이미지", "사진"],
     icon: <ImageIcon size={18} />,
     command: ({ editor, range }) => {
-      const url = promptForImageUrl();
-      if (!url) return;
-      editor.chain().focus().deleteRange(range).setImage({ src: url }).run();
+      // URL 입력이 아니라 파일을 첨부해 이미지를 삽입한다.
+      editor.chain().focus().deleteRange(range).run();
+      void pickImageFile().then((dataUrl) => {
+        if (dataUrl) {
+          editor.chain().focus().setImage({ src: dataUrl }).run();
+        }
+      });
     },
   },
 ];
@@ -124,11 +128,32 @@ const isSafeImageUrl = (raw: string): boolean => {
   }
 };
 
-const promptForImageUrl = (): string | null => {
-  if (typeof window === "undefined" || typeof window.prompt !== "function") return null;
-  const input = window.prompt("이미지 URL을 입력하세요:");
-  if (input === null) return null;
-  return isSafeImageUrl(input) ? input.trim() : null;
+// 파일 첨부로 선택한 이미지를 data URL(base64)로 읽어 반환한다.
+const pickImageFile = (): Promise<string | null> => {
+  return new Promise((resolve) => {
+    if (typeof document === "undefined") {
+      resolve(null);
+      return;
+    }
+    const input = document.createElement("input");
+    input.type = "file";
+    input.accept = "image/*";
+    input.onchange = () => {
+      const file = input.files?.[0];
+      if (!file) {
+        resolve(null);
+        return;
+      }
+      const reader = new FileReader();
+      reader.onload = () => {
+        const result = typeof reader.result === "string" ? reader.result : null;
+        resolve(result && isSafeImageUrl(result) ? result : null);
+      };
+      reader.onerror = () => resolve(null);
+      reader.readAsDataURL(file);
+    };
+    input.click();
+  });
 };
 
 type MenuState = {
@@ -138,13 +163,14 @@ type MenuState = {
   selectedIndex: number;
 };
 
-const getContainerClasses = (className: string): string => {
-  const baseClasses = "w-full border border-[var(--border-default,#cccccc)] rounded-lg bg-white";
-  return [baseClasses, className].filter(Boolean).join(" ");
+const getContainerClasses = (isEditable: boolean, className: string): string => {
+  // 편집 모드에서만 입력 박스(테두리/배경)를 보여주고, 읽기 전용은 콘텐츠만 표시한다.
+  const editableBoxClasses = "border border-[var(--border-default,#cccccc)] rounded-lg bg-white";
+  return ["w-full", isEditable ? editableBoxClasses : "", className].filter(Boolean).join(" ");
 };
 
-const editorContentClasses = [
-  "w-full min-h-[240px] px-4 py-3",
+const editorContentBaseClasses = [
+  "w-full",
   "[&_.ProseMirror]:outline-none",
   "[&_.ProseMirror_h1]:text-[2rem] [&_.ProseMirror_h1]:font-bold [&_.ProseMirror_h1]:leading-tight [&_.ProseMirror_h1]:mb-3 [&_.ProseMirror_h1]:mt-4",
   "[&_.ProseMirror_h2]:text-[1.5rem] [&_.ProseMirror_h2]:font-semibold [&_.ProseMirror_h2]:leading-snug [&_.ProseMirror_h2]:mb-2 [&_.ProseMirror_h2]:mt-4",
@@ -165,6 +191,10 @@ const editorContentClasses = [
   "[&_.ProseMirror_p.is-editor-empty:first-child::before]:pointer-events-none",
   "[&_.ProseMirror_p.is-editor-empty:first-child::before]:h-0",
 ].join(" ");
+
+// 편집 모드에서만 입력 영역 여백/최소 높이를 준다. 읽기 전용은 콘텐츠만 노출한다.
+const getEditorContentClasses = (isEditable: boolean): string =>
+  [editorContentBaseClasses, isEditable ? "min-h-[240px] px-4 py-3" : ""].filter(Boolean).join(" ");
 
 export const RichEditor = ({
   content = "",
@@ -283,8 +313,8 @@ export const RichEditor = ({
   }, [editor, isEditable]);
 
   return (
-    <div className={getContainerClasses(className)}>
-      <EditorContent editor={editor} className={editorContentClasses} />
+    <div className={getContainerClasses(isEditable, className)}>
+      <EditorContent editor={editor} className={getEditorContentClasses(isEditable)} />
       {isEditable && menuState && (
         <SlashCommandMenu
           items={menuState.items}


### PR DESCRIPTION
## 🔎 What is this PR?

- 그동안 `dev`에 머지된 작업 8건을 `main`으로 반영하는 릴리스 PR 

---

## 📝 Changes

머지된 PR 기준 (`main..dev` 8커밋, 62파일 +3331/-207)

- #156 [Fix] #154 - 포트폴리오/포트폴리오 작성 페이지 하단 푸터 누락 수정
- #149 [Feat] #126 - 공지등록 페이지 구현
- #146 [Feat] #128 - 관리자 페이지 구현
- #127 [Feat] #125 - 공지사항 페이지 구현 및 공지 조회
- #133 [Feat] #132 - 포트폴리오 작성/수정 페이지 구현
- #147 [Feat] #134 - 목록 GET 응답 클라이언트 캐싱
- #145 [Feat] #144 - 공용 Loading 컴포넌트 및 페이지 전환 애니메이션 구현
- #143 [Feat] #138 - 기업 회원가입 아이디 필드 제거

---

## 📚 Background / Context (선택)

- 지금까지 `dev`에서만 작업이 진행됐고 `main`은 갱신되지 않아, 배포 브랜치와 개발 브랜치가 8커밋 벌어져 있었습니다
- `main` push 시 `firebase-hosting-merge.yml`이 동작해 **라이브 배포가 시작**됩니다 (#139/#140에서 정비한 워크플로)
- `firebase.json`은 `/api/**`를 Cloud Run `aim-be-prod`(us-central1)로 rewrite합니다. `.env.production`의 `NEXT_PUBLIC_BACKEND_API_BASE_URL`은 빈 값으로 유지되어 rewrite 경유가 맞게 설정돼 있습니다
- `main`에만 있는 커밋 2건(#139 pnpm 버전 단일화, Firebase 배포 트리거)은 이 머지로 `dev` 이력과 합쳐집니다

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build` — 정적 export 16페이지 생성 확인)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
- [x] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료 (`tsc --noEmit` 클린, 백엔드 연동 응답 200 확인)
