### PR TITLE
[Fix] #163 - 홈(/home) figma design 대비 디자인 스펙 불일치

### DIFF
--- a/src/screens/home/home.tsx
+++ b/src/screens/home/home.tsx
@@ -238,7 +238,7 @@ export const HomePage: React.FC = () => {
 
       {/* Hero Banner */}
       <section className="bg-white pb-0 pt-[10px]">
-        <div className="mx-auto max-w-360">
+        <div className="mx-auto w-full max-w-360 px-6 min-[1440px]:px-0">
           <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 xl:grid-cols-4">
             {HERO_CARDS.map((card, i) => (
               <div
@@ -284,7 +284,7 @@ export const HomePage: React.FC = () => {
         </div>
       </section>
 
-      <main className="mx-auto w-full max-w-360 py-12 md:py-16">
+      <main className="mx-auto w-full max-w-360 px-6 py-12 min-[1440px]:px-0 md:py-16">
         {/* 새로 올라온 포트폴리오 */}
         <section className="mb-[60px]">
           <SectionHeader title="새로 올라온 포트폴리오" href="/portfolio" />

--- a/src/screens/home/home.tsx
+++ b/src/screens/home/home.tsx
@@ -58,7 +58,8 @@ const HERO_CARDS = [
 ];
 
 const SECTION_FILTERS: SectionFilter[] = ["학생 포트폴리오", "기업 모집공고", "연구실"];
-const POST_GRID_CLASSES = "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+const POST_GRID_CLASSES =
+  "grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
 const POST_GRID_STATE_MIN_HEIGHT = "min-h-[420px]";
 const HOME_POST_SKELETON_COUNT = 4;
 
@@ -73,13 +74,13 @@ const formatDate = (isoString: string): string => {
 
 const SectionHeader = ({ title, href }: { title: string; href?: string }) => (
   <div className="mb-6 flex items-center justify-between">
-    <h2 className="text-[24px] font-bold leading-tight tracking-[-0.6px] text-gray-900">{title}</h2>
+    <h2 className="text-[40px] font-bold leading-[1.3] tracking-[-1px] text-gray-900">{title}</h2>
     {href && (
       <Link
         href={href}
-        className="text-[14px] font-medium text-gray-500 hover:text-(--color-primary-800) transition-colors"
+        className="text-[16px] font-normal text-gray-500 underline hover:text-(--color-primary-800) transition-colors"
       >
-        더보기 &gt;
+        더보기
       </Link>
     )}
   </div>
@@ -236,16 +237,16 @@ export const HomePage: React.FC = () => {
       />
 
       {/* Hero Banner */}
-      <section className="bg-white px-6 pb-0 pt-10 md:px-16 md:pt-14">
+      <section className="bg-white pb-0 pt-[10px]">
         <div className="mx-auto max-w-360">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 xl:grid-cols-4">
             {HERO_CARDS.map((card, i) => (
               <div
                 key={i}
                 className={`relative flex flex-col overflow-hidden rounded-3xl ${card.bg} text-[#f9f9f9]`}
               >
                 <div className="flex flex-col gap-2 p-6">
-                  <span className="inline-block w-fit rounded-xl border border-[#f9f9f9]/70 px-3 py-1 text-[12px] font-medium tracking-[-0.3px]">
+                  <span className="inline-block w-fit rounded-xl border border-[#f9f9f9] px-3 py-1 text-[12px] font-medium tracking-[-0.3px]">
                     {card.badge}
                   </span>
                   <h3 className="whitespace-pre-line text-2xl font-semibold leading-snug tracking-[-0.6px]">
@@ -260,7 +261,7 @@ export const HomePage: React.FC = () => {
                   <img
                     src={card.icon}
                     alt={`${card.title.replace(/\n/g, " ")} 아이콘`}
-                    className="h-35 w-auto object-contain"
+                    className="size-[200px] object-cover"
                   />
                 </div>
               </div>
@@ -270,9 +271,9 @@ export const HomePage: React.FC = () => {
           {/* Hero Search Bar */}
           <form
             onSubmit={handleHeroSearch}
-            className="mt-4 flex items-center gap-3 rounded-xl bg-[#0056b3] px-5 py-3"
+            className="mt-[25px] flex items-center gap-2 rounded-[100px] bg-[#0056b3] px-4 py-2.5"
           >
-            <SearchIcon size={18} className="shrink-0 text-white/60" />
+            <SearchIcon size={20} className="shrink-0 text-white/60" />
             <input
               ref={searchRef}
               type="text"
@@ -283,28 +284,28 @@ export const HomePage: React.FC = () => {
         </div>
       </section>
 
-      <main className="mx-auto w-full max-w-360 px-6 py-12 md:px-16 md:py-16">
+      <main className="mx-auto w-full max-w-360 py-12 md:py-16">
         {/* 새로 올라온 포트폴리오 */}
-        <section className="mb-16">
+        <section className="mb-[60px]">
           <SectionHeader title="새로 올라온 포트폴리오" href="/portfolio" />
           <PostGrid posts={newPosts} isLoading={isLoadingNew} error={newPostsError} />
         </section>
 
         {/* 아주대학교와 함께하세요 */}
-        <section id="about" className="mb-16">
-          <h2 className="mb-6 text-center text-[28px] font-bold leading-tight tracking-[-0.7px] text-gray-900">
+        <section id="about" className="mb-[60px]">
+          <h2 className="mb-6 text-center text-[40px] font-bold leading-[1.3] tracking-[-1px] text-gray-900">
             아주대학교와 함께하세요.
           </h2>
-          <div className="mb-6 flex justify-center gap-2">
+          <div className="mb-[40px] flex gap-4">
             {SECTION_FILTERS.map((filter) => (
               <button
                 key={filter}
                 onClick={() => setSectionFilter(filter)}
                 className={[
-                  "rounded-full px-5 py-2 text-[14px] font-semibold transition-all",
+                  "rounded-full px-6 py-2.5 text-[14px] font-medium transition-all",
                   sectionFilter === filter
                     ? "bg-(--color-primary-800) text-white"
-                    : "border border-gray-200 bg-white text-gray-600 hover:border-(--color-primary-800) hover:text-(--color-primary-800)",
+                    : "border border-(--color-primary-800) bg-white text-(--color-primary-800)",
                 ].join(" ")}
               >
                 {filter}
@@ -330,13 +331,13 @@ export const HomePage: React.FC = () => {
           ) : noticePosts.length === 0 ? (
             <EmptyState variant="no-content" title="공지사항이 없습니다." />
           ) : (
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {noticePosts.map((post) => (
                 <Card
                   key={post.postId}
                   variant="post"
                   href={`/notice/detail?id=${post.postId}`}
-                  thumbnail={post.thumbnailImage}
+                  hideThumbnail
                   tags={post.keywords}
                   title={post.title}
                   description={post.description}

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -32,6 +32,8 @@ interface PostCardSpecificProps {
   variant: "post";
   href?: string;
   thumbnail?: string | { src: string };
+  // true면 썸네일 영역을 렌더하지 않는 compact 카드 (공지 등)
+  hideThumbnail?: boolean;
   tags?: string[];
   title: string;
   description: string;
@@ -99,6 +101,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
     const {
       href,
       thumbnail,
+      hideThumbnail = false,
       tags,
       title,
       description,
@@ -132,7 +135,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
     const content = (
       <>
         <div
-          className={`relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden bg-[var(--color-gray-100,#f5f5f5)] ${linkedBorderHoverClasses}`}
+          className={`relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden bg-[var(--color-gray-100,#f5f5f5)] ${hideThumbnail ? "hidden" : ""} ${linkedBorderHoverClasses}`}
         >
           {thumbnail ? (
             <img
@@ -162,7 +165,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
         </div>
 
         <div
-          className={`bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 rounded-b-xl ${linkedBorderHoverClasses}`}
+          className={`bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 ${hideThumbnail ? "rounded-xl" : "rounded-b-xl"} ${linkedBorderHoverClasses}`}
         >
           {tags && tags.length > 0 && (
             <div className="flex gap-2 flex-wrap">


### PR DESCRIPTION
## 🔎 What is this PR?

- 홈(/home)을 figma design 스펙에 맞게 정렬 (타이포·간격·검색바·넓은 뷰포트 정렬·공지 썸네일 없는 카드)

---

## 📝 Changes

- 섹션 제목 40px(bold, -1px), "더보기" 밑줄·16px·화살표 제거 / 중앙 헤딩 40px
- 히어로: 아이콘 200px(object-cover), 뱃지 테두리 solid, 카드 gap 10px, 상단 pt 10px, 검색바 gap 25px
- 필터: **좌측 정렬**, 컨테이너 gap 16px, 버튼 px-6 py-2.5·font-medium, 비활성 버튼 **파랑(primary-800)**
- 카드 그리드 gap 10px, 섹션 간 간격 60px
- 검색바 `rounded-full`(pill)·패딩·아이콘 20px
- **넓은 뷰포트(>1440px) 정렬**: 히어로/본문의 `px` 제거 → 검색바·카드 모두 full 1440으로 정렬
- **공지 섹션 썸네일 없는 카드**: `Card`에 `hideThumbnail` prop 추가, 공지 카드에 적용

---

## 📸 Screenshots (선택)

---

## 📚 Background / Context (선택)

- #163 디자인 QA 발견 사항 반영

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수
- [ ] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료

---

## 🙏 Request

- 넓은 뷰포트 정렬(px 제거)과 공지 썸네일 없는 카드 표시 확인 부탁드립니다.
