### PR TITLE
[Fix] #169 - 포트폴리오 상세 버튼(시연영상/Github/좋아요) roundness·border 굵기 불일치

### DIFF
--- a/src/screens/portfolio-detail/portfolio-detail-page.tsx
+++ b/src/screens/portfolio-detail/portfolio-detail-page.tsx
@@ -219,6 +219,7 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
                       <Button
                         variant="secondary"
                         size="small"
+                        isPill
                         iconPosition="right"
                         icon={<ExternalLinkIcon size={16} />}
                         onClick={() => openExternalLink(detail.videoLink as string)}
@@ -230,6 +231,7 @@ export const PortfolioDetailPage = ({ postId, boardType }: PortfolioDetailPagePr
                       <Button
                         variant="secondary"
                         size="small"
+                        isPill
                         iconPosition="right"
                         icon={<ExternalLinkIcon size={16} />}
                         onClick={() => openExternalLink(detail.githubLink as string)}

--- a/src/screens/portfolio-detail/portfolio-like-button.tsx
+++ b/src/screens/portfolio-detail/portfolio-like-button.tsx
@@ -54,6 +54,7 @@ export const PortfolioLikeButton = ({
     <Button
       variant={isLiked ? "primary" : "secondary"}
       size="small"
+      isPill
       iconPosition="left"
       icon={<HeartIcon size={16} filled={isLiked} />}
       onClick={handleClick}

--- a/src/shared/ui/button/button.tsx
+++ b/src/shared/ui/button/button.tsx
@@ -12,6 +12,7 @@ export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElemen
   icon?: React.ReactNode;
   children?: React.ReactNode; // 버튼 텍스트 (없으면 IconButton으로 동작)
   fullWidth?: boolean;
+  isPill?: boolean; // 완전 둥근(pill) 모서리
   isLoading?: boolean;
   disabled?: boolean;
   onClick?: () => void;
@@ -27,6 +28,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       icon,
       children,
       fullWidth = false,
+      isPill = false,
       isLoading = false,
       disabled = false,
       className = "",
@@ -50,12 +52,18 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
           large: "w-12 h-12 p-0",
         }
       : {
-          small: "h-8 px-4 text-[14px] leading-[20px] rounded-[6px] gap-1.5",
-          medium: "h-10 px-6 text-[14px] leading-[20px] rounded-lg gap-2",
-          large: "h-12 px-8 text-[16px] leading-[24px] rounded-lg gap-2",
+          small: "h-8 px-4 text-[14px] leading-[20px] gap-1.5",
+          medium: "h-10 px-6 text-[14px] leading-[20px] gap-2",
+          large: "h-12 px-8 text-[16px] leading-[24px] gap-2",
         };
 
-    const borderRadiusClass = isIconOnly ? "rounded-lg" : "";
+    const borderRadiusClass = isPill
+      ? "rounded-full"
+      : isIconOnly
+        ? "rounded-lg"
+        : size === "small"
+          ? "rounded-[6px]"
+          : "rounded-lg";
 
     const variantClasses = {
       primary: {
@@ -67,11 +75,11 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
       },
       secondary: {
         default:
-          "bg-transparent border-2 border-[var(--color-primary-800)] text-[var(--color-primary-800)] hover:bg-[var(--color-primary-50)] hover:border-[var(--color-primary-700)] hover:text-[var(--color-primary-700)] active:bg-[var(--color-primary-100)] active:border-[var(--color-primary-900)] active:text-[var(--color-primary-900)]",
+          "bg-transparent border border-[var(--color-primary-800)] text-[var(--color-primary-800)] hover:bg-[var(--color-primary-50)] hover:border-[var(--color-primary-700)] hover:text-[var(--color-primary-700)] active:bg-[var(--color-primary-100)] active:border-[var(--color-primary-900)] active:text-[var(--color-primary-900)]",
         disabled:
-          "bg-transparent border-2 border-[var(--color-gray-300)] text-[var(--color-gray-400)] cursor-not-allowed opacity-60",
+          "bg-transparent border border-[var(--color-gray-300)] text-[var(--color-gray-400)] cursor-not-allowed opacity-60",
         loading:
-          "bg-transparent border-2 border-[var(--color-primary-800)] text-[var(--color-primary-800)] cursor-wait",
+          "bg-transparent border border-[var(--color-primary-800)] text-[var(--color-primary-800)] cursor-wait",
       },
       ghost: {
         default:


### PR DESCRIPTION
## 🔎 What is this PR?

- 포트폴리오 상세 버튼(시연영상/Github/좋아요)을 pill 모서리로, 아웃라인 버튼 테두리를 1px로 (design 기준)

---

## 📝 Changes

- `Button`에 `isPill` prop 추가 (rounded를 size에서 분리, pill 시 `rounded-full`)
- `Button` `secondary` variant 테두리 `border-2` → `border`(**1px**) — figma 표준 아웃라인 두께
- 상세 페이지 시연영상/Github 버튼, 좋아요 버튼에 `isPill` 적용 (pill + 1px)

---

## 📸 Screenshots (선택)

---

## 📚 Background / Context (선택)

- #169 디자인 QA 발견 사항 반영. 테두리 1px 변경은 앱 전역 아웃라인(secondary) 버튼에 공통 적용됩니다.

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수
- [ ] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료

---

## 🙏 Request

- secondary 버튼 테두리 1px이 전역에 적용되니 다른 화면 아웃라인 버튼도 함께 확인 부탁드립니다.
