### PR TITLE
[Fix] #170 - 프로필(/profile) design 대비 아바타 크기·헤더 간격·편집 버튼 불일치

### DIFF
--- a/src/screens/profile/profile-content.tsx
+++ b/src/screens/profile/profile-content.tsx
@@ -99,21 +99,25 @@ export const ProfileContent = () => {
     <main className="min-h-screen bg-white">
       <div className={containerClasses}>
         {/* 프로필 헤더 */}
-        <section className="flex flex-col gap-8 sm:flex-row sm:items-start sm:gap-[60px]">
-          <Avatar name={profile.name} size="3xl" className="flex-shrink-0" />
+        <section className="flex flex-col gap-8 sm:flex-row sm:items-start sm:gap-[100px]">
+          <Avatar name={profile.name} size="4xl" className="flex-shrink-0" />
 
           <div className="flex-1">
             <div className="flex flex-wrap items-center gap-3">
               <h1 className="text-[20px] text-[color:var(--color-gray-900,#111)]">
                 {profile.name}
               </h1>
-              <Button variant="secondary" size="medium" onClick={() => setIsEditOpen(true)}>
+              <button
+                type="button"
+                onClick={() => setIsEditOpen(true)}
+                className="inline-flex h-[40px] items-center rounded-lg border border-[#e5e5e5] px-6 py-[10px] text-[14px] font-medium text-[#111] transition-colors hover:bg-gray-50"
+              >
                 프로필 편집
-              </Button>
+              </button>
               <Button
                 variant="primary"
                 size="medium"
-                icon={<UploadIcon />}
+                icon={<UploadIcon size={18} />}
                 iconPosition="left"
                 onClick={() => router.push("/portfolio/create")}
               >
@@ -143,7 +147,7 @@ export const ProfileContent = () => {
               {profile.department}
             </p>
             {profile.profileBio && (
-              <p className="mt-1 text-[14px] text-[color:var(--color-gray-500,#666)]">
+              <p className="mt-1 text-[14px] text-[color:var(--color-gray-600,#666)]">
                 {profile.profileBio}
               </p>
             )}

--- a/src/shared/ui/avatars/avatars.tsx
+++ b/src/shared/ui/avatars/avatars.tsx
@@ -6,7 +6,7 @@ import { UserSolidIcon } from "../icons";
 // ----------------------------------------------------------------------
 // 타입 정의
 // ----------------------------------------------------------------------
-export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl";
+export type AvatarSize = "xs" | "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl";
 export type AvatarStatus = "online" | "away" | "busy" | "offline";
 
 export type AvatarProps = {
@@ -42,6 +42,7 @@ const avatarSizeClasses: Record<AvatarSize, string> = {
   xl: "w-[64px] h-[64px]",
   "2xl": "w-[96px] h-[96px]",
   "3xl": "w-[128px] h-[128px]",
+  "4xl": "w-[150px] h-[150px]",
 };
 
 // 비율에 맞춘 텍스트 사이즈
@@ -53,6 +54,7 @@ const avatarTextSizeClasses: Record<AvatarSize, string> = {
   xl: "text-[26px]",
   "2xl": "text-[38px]",
   "3xl": "text-[51px]",
+  "4xl": "text-[48px]",
 };
 
 // 비율에 맞춘 상태 표시기 사이즈
@@ -64,6 +66,7 @@ const statusSizeClasses: Record<AvatarSize, string> = {
   xl: "w-[13px] h-[13px] border-[2px]",
   "2xl": "w-[19px] h-[19px] border-[3px]",
   "3xl": "w-[26px] h-[26px] border-[4px]",
+  "4xl": "w-[30px] h-[30px] border-[4px]",
 };
 
 const statusColorClasses: Record<AvatarStatus, string> = {


### PR DESCRIPTION
## 🔎 What is this PR?

- 프로필(/profile)을 design 기준으로 정렬 (아바타 크기·헤더 간격·프로필 편집 버튼)

---

## 📝 Changes

- 아바타 크기 128px(`3xl`) → **150px** (`Avatar`에 `4xl` 사이즈 추가)
- 헤더 아바타↔정보 간격 `gap-[60px]` → **`gap-[100px]`**
- 프로필 편집 버튼: 파란 `secondary` → **중립 아웃라인(테두리 `#e5e5e5` + 글자 `#111`, 1px)**
- 소개(bio) 글자색 gray-500 → **gray-600(`#666`)**
- 포트폴리오 업로드 아이콘 `size={18}` 지정

---

## 📸 Screenshots (선택)

---

## 📚 Background / Context (선택)

- #170 디자인 QA 발견 사항 반영. 탭(하단 밑줄·아이콘 없음)은 portfolio-figma 기준으로 정상이라 제외.

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수
- [ ] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료

---

## 🙏 Request

- 아바타 크기(150)·프로필 편집 버튼 중립 아웃라인 확인 부탁드립니다.
