### PR TITLE
[Fix] #161 - 좋아요/포트폴리오 작성·수정·삭제 후 목록 캐시 무효화

### DIFF
--- a/src/lib/posts/use-create-portfolio.ts
+++ b/src/lib/posts/use-create-portfolio.ts
@@ -8,6 +8,7 @@ import {
   type PortfolioCreateRequest,
   type PortfolioDetail,
 } from "@/api/posts";
+import { clearListCache } from "@/api/cache";
 
 export type UseCreatePortfolioResult = {
   submit: (
@@ -38,7 +39,9 @@ export const useCreatePortfolio = (): UseCreatePortfolioResult => {
       setIsSubmitting(true);
       setError(null);
       try {
-        return await createPortfolio(boardType, request, files);
+        const result = await createPortfolio(boardType, request, files);
+        clearListCache();
+        return result;
       } catch (cause) {
         console.error("포트폴리오 저장에 실패했습니다.", cause);
         setError(toErrorInstance(cause));

--- a/src/lib/posts/use-delete-portfolio.ts
+++ b/src/lib/posts/use-delete-portfolio.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { deletePortfolio, type PortfolioBoardType } from "@/api/posts";
+import { clearListCache } from "@/api/cache";
 
 export type UseDeletePortfolioResult = {
   remove: (boardType: PortfolioBoardType, postId: number) => Promise<boolean>;
@@ -24,6 +25,7 @@ export const useDeletePortfolio = (): UseDeletePortfolioResult => {
     setError(null);
     try {
       await deletePortfolio(boardType, postId);
+      clearListCache();
       return true;
     } catch (cause) {
       console.error("포트폴리오 삭제에 실패했습니다.", cause);

--- a/src/lib/posts/use-toggle-post-like.ts
+++ b/src/lib/posts/use-toggle-post-like.ts
@@ -2,6 +2,7 @@
 
 import { useCallback, useState } from "react";
 import { togglePostLike, type PostLikeToggleResponse } from "@/api/posts";
+import { clearListCache } from "@/api/cache";
 
 export type UseTogglePostLikeResult = {
   toggle: (postId: number) => Promise<PostLikeToggleResponse | null>;
@@ -24,6 +25,7 @@ export const useTogglePostLike = (): UseTogglePostLikeResult => {
     setError(null);
     try {
       const response = await togglePostLike(postId);
+      clearListCache();
       return response;
     } catch (cause) {
       setError(toErrorInstance(cause));

--- a/src/lib/posts/use-update-portfolio.ts
+++ b/src/lib/posts/use-update-portfolio.ts
@@ -8,6 +8,7 @@ import {
   type PortfolioDetail,
   type PortfolioUpdateRequest,
 } from "@/api/posts";
+import { clearListCache } from "@/api/cache";
 
 export type UseUpdatePortfolioResult = {
   submit: (
@@ -40,7 +41,9 @@ export const useUpdatePortfolio = (): UseUpdatePortfolioResult => {
       setIsSubmitting(true);
       setError(null);
       try {
-        return await updatePortfolio(boardType, postId, request, files);
+        const result = await updatePortfolio(boardType, postId, request, files);
+        clearListCache();
+        return result;
       } catch (cause) {
         console.error("포트폴리오 수정에 실패했습니다.", cause);
         setError(toErrorInstance(cause));


### PR DESCRIPTION
## 🔎 What is this PR?

- 목록 GET 응답 캐시(#134, PR #147)가 좋아요/포트폴리오 작성·수정·삭제 후 무효화되지 않던 문제 수정

---

## 📝 Changes

- 아래 4개 mutation 훅의 성공 지점에서 `clearListCache()` 호출 추가 (관리자 공지 저장/삭제가 이미 쓰던 패턴과 동일)
  - `src/lib/posts/use-toggle-post-like.ts` — 좋아요 토글
  - `src/lib/posts/use-create-portfolio.ts` — 포트폴리오 작성
  - `src/lib/posts/use-update-portfolio.ts` — 포트폴리오 수정
  - `src/lib/posts/use-delete-portfolio.ts` — 포트폴리오 삭제

---

## 📚 Background / Context

- Issue #161: `clearListCache()` 호출부가 관리자 공지 저장/삭제 한 곳뿐이라, 좋아요/포트폴리오 작성·수정·삭제 후 목록(및 검색, 홈 섹션)이 캐시 TTL(30초) 동안 이전 상태로 남아 있었음
- 좋아요를 누르고 목록으로 돌아오면 카운트/하트 상태가 이전 값으로 보이고, `POPULAR` 정렬 순서가 어긋날 수 있었음. 포트폴리오 작성/삭제 직후에도 목록에 즉시 반영되지 않았음
- 캐시 TTL을 줄이는 방향은 캐시를 넣은 원래 목적(#134, 콜드스타트/리전 지연 완화)을 흐리므로 채택하지 않음
- `src/api/cache.ts`의 만료 엔트리 정리(`MAX_ENTRIES` 상한/sweep)는 이슈에서 별도 개선으로 제안된 사항이라 이번 PR 범위에서는 제외함

---

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`)
- [x] ESLint / Prettier 통과 (`pnpm lint`, `pnpm exec prettier --check`)
- [x] 네이밍/레이어 컨벤션 준수
- [x] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료 (`tsc --noEmit` 클린)

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated portfolio lists immediately after creating, editing, or deleting a portfolio.
  * Refreshed post lists after liking or unliking posts, ensuring changes appear without stale data.
