### PR TITLE
[Feat] #119 - 관리자 모드 토글 연동 (Navigation)

### DIFF
--- a/src/app/app-layout.tsx
+++ b/src/app/app-layout.tsx
@@ -2,7 +2,7 @@
 
 import type { ReactElement, ReactNode } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { signOut, toNavUser, useAuthSession } from "@/lib/auth";
+import { signOut, toNavUser, useAdminMode, useAuthSession } from "@/lib/auth";
 import { Navigation, type NavItem } from "@/shared/ui";
 
 type AppLayoutProps = Readonly<{
@@ -29,6 +29,7 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
       (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
     );
   const navigationUser = toNavUser(session) ?? undefined;
+  const { isAdminMode, toggleAdminMode } = useAdminMode(navigationUser?.isAdmin ?? false);
 
   const handleLoginClick = () => {
     router.push("/login");
@@ -59,6 +60,9 @@ export const AppLayout = ({ children }: AppLayoutProps): ReactElement => {
           onSignup={handleSignupClick}
           onLogout={handleLogoutClick}
           onProfileClick={() => router.push("/profile")}
+          isAdminMode={isAdminMode}
+          onAdminToggle={toggleAdminMode}
+          onAdminDashboardClick={() => router.push("/admin")}
         />
       )}
       {children}

--- a/src/lib/auth/index.ts
+++ b/src/lib/auth/index.ts
@@ -9,6 +9,7 @@ export type { AuthSession, StoredSession } from "./auth-session";
 export { getAuthErrorMessage } from "./auth-error-message";
 export { authRoleLabels } from "./auth-role-labels";
 export { toNavUser } from "./to-nav-user";
+export { useAdminMode } from "./use-admin-mode";
 export { useAuthUser } from "./use-auth-user";
 export { useAuthReady, type AuthReadyState } from "./use-auth-ready";
 export type { AuthRole, BackendLoginRequest, BackendUser } from "@/api/auth";

--- a/src/lib/auth/use-admin-mode.ts
+++ b/src/lib/auth/use-admin-mode.ts
@@ -1,0 +1,46 @@
+"use client";
+
+import { useCallback, useSyncExternalStore } from "react";
+
+const ADMIN_MODE_STORAGE_KEY = "aim.admin-mode";
+const ADMIN_MODE_EVENT = "aim:admin-mode-changed";
+
+type UseAdminModeResult = {
+  isAdminMode: boolean;
+  toggleAdminMode: () => void;
+};
+
+const readStoredAdminMode = (): boolean =>
+  window.localStorage.getItem(ADMIN_MODE_STORAGE_KEY) === "true";
+
+// 같은 탭은 커스텀 이벤트로, 다른 탭은 storage 이벤트로 갱신을 받는다.
+const subscribe = (onStoreChange: () => void): (() => void) => {
+  window.addEventListener(ADMIN_MODE_EVENT, onStoreChange);
+  window.addEventListener("storage", onStoreChange);
+
+  return () => {
+    window.removeEventListener(ADMIN_MODE_EVENT, onStoreChange);
+    window.removeEventListener("storage", onStoreChange);
+  };
+};
+
+// 정적 export 시점에는 localStorage가 없으므로 일반 모드로 렌더한다.
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * 관리자 모드(일반 모드 ↔ 관리 모드) 상태를 다룬다.
+ *
+ * 새로고침·페이지 이동 후에도 유지되도록 localStorage에 저장한다.
+ * 관리자가 아닌 사용자에게는 저장된 값과 무관하게 항상 false를 반환한다.
+ * (계정을 바꿔 로그인했을 때 이전 사용자의 모드가 남지 않도록)
+ */
+export const useAdminMode = (isAdmin: boolean): UseAdminModeResult => {
+  const isStoredAdminMode = useSyncExternalStore(subscribe, readStoredAdminMode, getServerSnapshot);
+
+  const toggleAdminMode = useCallback(() => {
+    window.localStorage.setItem(ADMIN_MODE_STORAGE_KEY, String(!readStoredAdminMode()));
+    window.dispatchEvent(new Event(ADMIN_MODE_EVENT));
+  }, []);
+
+  return { isAdminMode: isAdmin && isStoredAdminMode, toggleAdminMode };
+};


### PR DESCRIPTION
## 🔎 What is this PR?

- `Navigation`에 이미 구현돼 있던 관리자 모드 토글을 `AppLayout`과 연결해 실제로 동작하게 함 (#119)

---

## 📝 Changes

- `src/lib/auth/use-admin-mode.ts` 신설
  - 모드 상태를 `localStorage`(`aim.admin-mode`)에 저장해 새로고침·페이지 이동 후에도 유지
  - `useSyncExternalStore`로 구독 — 같은 탭은 커스텀 이벤트, 다른 탭은 `storage` 이벤트로 즉시 반영
  - 관리자가 아니면 저장값과 무관하게 항상 일반 모드를 반환
- `src/app/app-layout.tsx`: `isAdminMode` / `onAdminToggle` / `onAdminDashboardClick`(→ `/admin`) 전달
- `src/lib/auth/index.ts`: `useAdminMode` export 추가

---

## 📚 Background / Context (선택)

- 토글 UI·props(`isAdminMode`, `onAdminToggle`, 라벨, 대시보드 항목)는 `navigation.tsx`에 이미 있었고, `AppLayout`이 값을 넘기지 않아 렌더되지 않던 상태였습니다
- 지속성 정책은 이슈에서 "정의 필요"로 열려 있어 **localStorage**로 잡았습니다. 세션 종료 시 초기화가 맞다면 `sessionStorage`로 바꾸면 됩니다
- 비관리자 노출 방지를 훅 반환값(`isAdmin && 저장값`)에서 처리했습니다. `navigation.tsx`의 "관리자 대시보드" 항목이 `isAdminMode` 조건만으로 렌더되기 때문에, 계정을 바꿔 로그인했을 때 이전 사용자의 모드가 남아 있으면 비관리자에게도 노출될 수 있어서입니다
- 상태 저장을 `setState` updater 밖에서 처리했습니다 (`reactStrictMode: true`라 updater가 두 번 호출될 수 있음)

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build` — 정적 export 17페이지)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수 (camelCase/PascalCase, is·has 불린 접두사, alias 계층 규칙)
- [x] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료
  - `tsc --noEmit` 클린
  - 정적 export 빌드 성공 = 렌더 중 `localStorage` 접근이 없어 하이드레이션 안전
  - dev 서버로 `/home/`·`/portfolio/` 200 확인, `useSyncExternalStore` 관련 런타임 경고(무한 렌더/`getSnapshot` 캐시) 없음

---

## 🙏 Request

- 지속성 정책(localStorage vs sessionStorage)이 의도와 맞는지 확인 부탁드립니다
- `AppLayout`은 `/admin` 경로에서 Navigation을 렌더하지 않고 `AdminLayout`이 자체 Navigation을 씁니다. 그래서 관리자 페이지 안에서는 토글이 보이지 않는데(로고로 나가면 다시 보임), 관리 화면에서도 모드를 끌 수 있어야 한다면 `AdminLayout`에도 같은 props를 넘기는 후속 작업이 필요합니다
- 이 PR로 `/admin` 진입점이 생기는데, `/admin` 라우트 자체의 권한 가드는 #160 에서 다루고 있습니다 (이 PR 스코프 밖)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an admin mode toggle for users with administrative access.
  * Admin mode remains synchronized across browser tabs and windows.
  * Added navigation support for switching to the admin dashboard.

* **Bug Fixes**
  * Non-admin users and server-rendered pages now default to standard mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->