### PR TITLE
[Release] dev → main

### DIFF
--- a/src/screens/home/home.tsx
+++ b/src/screens/home/home.tsx
@@ -58,7 +58,8 @@ const HERO_CARDS = [
 ];
 
 const SECTION_FILTERS: SectionFilter[] = ["학생 포트폴리오", "기업 모집공고", "연구실"];
-const POST_GRID_CLASSES = "grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
+const POST_GRID_CLASSES =
+  "grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4";
 const POST_GRID_STATE_MIN_HEIGHT = "min-h-[420px]";
 const HOME_POST_SKELETON_COUNT = 4;
 
@@ -73,13 +74,13 @@ const formatDate = (isoString: string): string => {
 
 const SectionHeader = ({ title, href }: { title: string; href?: string }) => (
   <div className="mb-6 flex items-center justify-between">
-    <h2 className="text-[24px] font-bold leading-tight tracking-[-0.6px] text-gray-900">{title}</h2>
+    <h2 className="text-[40px] font-bold leading-[1.3] tracking-[-1px] text-gray-900">{title}</h2>
     {href && (
       <Link
         href={href}
-        className="text-[14px] font-medium text-gray-500 hover:text-(--color-primary-800) transition-colors"
+        className="text-[16px] font-normal text-gray-500 underline hover:text-(--color-primary-800) transition-colors"
       >
-        더보기 &gt;
+        더보기
       </Link>
     )}
   </div>
@@ -236,16 +237,16 @@ export const HomePage: React.FC = () => {
       />
 
       {/* Hero Banner */}
-      <section className="bg-white px-6 pb-0 pt-10 md:px-16 md:pt-14">
-        <div className="mx-auto max-w-360">
-          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+      <section className="bg-white pb-0 pt-[10px]">
+        <div className="mx-auto w-full max-w-360 px-6 min-[1440px]:px-0">
+          <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 xl:grid-cols-4">
             {HERO_CARDS.map((card, i) => (
               <div
                 key={i}
                 className={`relative flex flex-col overflow-hidden rounded-3xl ${card.bg} text-[#f9f9f9]`}
               >
                 <div className="flex flex-col gap-2 p-6">
-                  <span className="inline-block w-fit rounded-xl border border-[#f9f9f9]/70 px-3 py-1 text-[12px] font-medium tracking-[-0.3px]">
+                  <span className="inline-block w-fit rounded-xl border border-[#f9f9f9] px-3 py-1 text-[12px] font-medium tracking-[-0.3px]">
                     {card.badge}
                   </span>
                   <h3 className="whitespace-pre-line text-2xl font-semibold leading-snug tracking-[-0.6px]">
@@ -260,7 +261,7 @@ export const HomePage: React.FC = () => {
                   <img
                     src={card.icon}
                     alt={`${card.title.replace(/\n/g, " ")} 아이콘`}
-                    className="h-35 w-auto object-contain"
+                    className="size-[200px] object-cover"
                   />
                 </div>
               </div>
@@ -270,9 +271,9 @@ export const HomePage: React.FC = () => {
           {/* Hero Search Bar */}
           <form
             onSubmit={handleHeroSearch}
-            className="mt-4 flex items-center gap-3 rounded-xl bg-[#0056b3] px-5 py-3"
+            className="mt-[25px] flex items-center gap-2 rounded-[100px] bg-[#0056b3] px-4 py-2.5"
           >
-            <SearchIcon size={18} className="shrink-0 text-white/60" />
+            <SearchIcon size={20} className="shrink-0 text-white/60" />
             <input
               ref={searchRef}
               type="text"
@@ -283,28 +284,28 @@ export const HomePage: React.FC = () => {
         </div>
       </section>
 
-      <main className="mx-auto w-full max-w-360 px-6 py-12 md:px-16 md:py-16">
+      <main className="mx-auto w-full max-w-360 px-6 py-12 min-[1440px]:px-0 md:py-16">
         {/* 새로 올라온 포트폴리오 */}
-        <section className="mb-16">
+        <section className="mb-[60px]">
           <SectionHeader title="새로 올라온 포트폴리오" href="/portfolio" />
           <PostGrid posts={newPosts} isLoading={isLoadingNew} error={newPostsError} />
         </section>
 
         {/* 아주대학교와 함께하세요 */}
-        <section id="about" className="mb-16">
-          <h2 className="mb-6 text-center text-[28px] font-bold leading-tight tracking-[-0.7px] text-gray-900">
+        <section id="about" className="mb-[60px]">
+          <h2 className="mb-6 text-center text-[40px] font-bold leading-[1.3] tracking-[-1px] text-gray-900">
             아주대학교와 함께하세요.
           </h2>
-          <div className="mb-6 flex justify-center gap-2">
+          <div className="mb-[40px] flex gap-4">
             {SECTION_FILTERS.map((filter) => (
               <button
                 key={filter}
                 onClick={() => setSectionFilter(filter)}
                 className={[
-                  "rounded-full px-5 py-2 text-[14px] font-semibold transition-all",
+                  "rounded-full px-6 py-2.5 text-[14px] font-medium transition-all",
                   sectionFilter === filter
                     ? "bg-(--color-primary-800) text-white"
-                    : "border border-gray-200 bg-white text-gray-600 hover:border-(--color-primary-800) hover:text-(--color-primary-800)",
+                    : "border border-(--color-primary-800) bg-white text-(--color-primary-800)",
                 ].join(" ")}
               >
                 {filter}
@@ -330,13 +331,13 @@ export const HomePage: React.FC = () => {
           ) : noticePosts.length === 0 ? (
             <EmptyState variant="no-content" title="공지사항이 없습니다." />
           ) : (
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            <div className="grid grid-cols-1 gap-[10px] sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
               {noticePosts.map((post) => (
                 <Card
                   key={post.postId}
                   variant="post"
                   href={`/notice/detail?id=${post.postId}`}
-                  thumbnail={post.thumbnailImage}
+                  hideThumbnail
                   tags={post.keywords}
                   title={post.title}
                   description={post.description}

--- a/src/screens/login/company-login-form.tsx
+++ b/src/screens/login/company-login-form.tsx
@@ -27,7 +27,10 @@ type CompanyLoginFormProps = {
 
 const inputClassName = "rounded-[4px] text-[14px] shadow-none";
 const signupInputClassName = "h-[44px] rounded-[4px] text-[14px] shadow-none md:h-12";
-const iconClassName = "!text-[#8c8c8c] hover:!text-[#8c8c8c]";
+const iconClassName =
+  "!text-[color:var(--color-gray-400,#999999)] hover:!text-[color:var(--color-gray-400,#999999)]";
+const submitButtonClassName =
+  "rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100";
 
 export const CompanyLoginForm = ({
   mode,
@@ -51,8 +54,8 @@ export const CompanyLoginForm = ({
           value={signupValues.companyName}
           onChange={(event) => onSignupValueChange("companyName", event.target.value)}
           disabled={isSubmitting}
-          placeholder="회사명"
-          aria-label="회사명"
+          placeholder="소속"
+          aria-label="소속"
           leftIcon={<BuildingIcon width={20} />}
           iconClassName={iconClassName}
           size="large"
@@ -121,7 +124,7 @@ export const CompanyLoginForm = ({
           fullWidth
           size="large"
           isLoading={isSubmitting}
-          className="mt-3 rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100"
+          className={`mt-3 ${submitButtonClassName}`}
         >
           회원가입
         </Button>
@@ -148,8 +151,8 @@ export const CompanyLoginForm = ({
         value={email}
         onChange={(event) => onEmailChange(event.target.value)}
         disabled={isSubmitting}
-        leftIcon={<MailIcon width={18} />}
-        iconClassName="!text-[#000000] hover:!text-[#000000]"
+        leftIcon={<MailIcon width={20} />}
+        iconClassName={iconClassName}
         size="large"
         isFullWidth
         className={inputClassName}
@@ -167,8 +170,8 @@ export const CompanyLoginForm = ({
         value={password}
         onChange={(event) => onPasswordChange(event.target.value)}
         disabled={isSubmitting}
-        leftIcon={<LockIcon width={18} />}
-        iconClassName="!text-[#000000] hover:!text-[#000000]"
+        leftIcon={<LockIcon width={20} />}
+        iconClassName={iconClassName}
         size="large"
         isFullWidth
         className={inputClassName}
@@ -179,7 +182,7 @@ export const CompanyLoginForm = ({
         fullWidth
         size="large"
         isLoading={isSubmitting}
-        className="mt-5 rounded-[4px] text-[14px] font-medium hover:scale-100 hover:shadow-none active:scale-100"
+        className={`mt-5 ${submitButtonClassName}`}
       >
         로그인
       </Button>

--- a/src/screens/login/index.tsx
+++ b/src/screens/login/index.tsx
@@ -214,7 +214,7 @@ export const LoginPage = () => {
                     }}
                     variant="horizontal"
                     isAnimated
-                    className="[&>button]:flex-1 [&>button]:text-[13px] [&>button]:md:text-[14px]"
+                    className="[&>button]:flex-1 [&>button]:text-[16px]"
                   />
                 </div>
 

--- a/src/screens/login/student-login-panel.tsx
+++ b/src/screens/login/student-login-panel.tsx
@@ -1,3 +1,4 @@
+import { GoogleIcon } from "@/shared/ui/icons";
 import { Spinner } from "@/shared/ui/spinner/spinner";
 
 type StudentLoginPanelProps = {
@@ -19,13 +20,7 @@ export const StudentLoginPanel = ({
       disabled={isSubmitting}
       className="mt-8 flex h-11 items-center justify-center gap-3 rounded-[4px] border border-[var(--color-gray-300)] bg-white px-5 text-[14px] font-medium text-[#4a4a4a] transition-colors duration-200 hover:border-[var(--color-primary-300)] hover:bg-[var(--color-primary-50)] disabled:cursor-wait disabled:opacity-70"
     >
-      {isSubmitting ? (
-        <Spinner size="small" />
-      ) : (
-        <span className="flex h-5 w-5 items-center justify-center rounded-full bg-[conic-gradient(from_90deg,#4285F4_0_25%,#34A853_25%_50%,#FBBC05_50%_75%,#EA4335_75%_100%)] text-[9px] font-bold text-white">
-          G
-        </span>
-      )}
+      {isSubmitting ? <Spinner size="small" /> : <GoogleIcon size={20} />}
       {isSubmitting ? "로그인 중..." : "Sign in with Google"}
     </button>
   </>

--- a/src/shared/ui/card/card.tsx
+++ b/src/shared/ui/card/card.tsx
@@ -32,6 +32,8 @@ interface PostCardSpecificProps {
   variant: "post";
   href?: string;
   thumbnail?: string | { src: string };
+  // true면 썸네일 영역을 렌더하지 않는 compact 카드 (공지 등)
+  hideThumbnail?: boolean;
   tags?: string[];
   title: string;
   description: string;
@@ -99,6 +101,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
     const {
       href,
       thumbnail,
+      hideThumbnail = false,
       tags,
       title,
       description,
@@ -132,7 +135,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
     const content = (
       <>
         <div
-          className={`relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden bg-[var(--color-gray-100,#f5f5f5)] ${linkedBorderHoverClasses}`}
+          className={`relative aspect-[360/203] w-full border border-[color:var(--color-gray-200,#e5e5e5)] border-b-0 rounded-t-xl overflow-hidden bg-[var(--color-gray-100,#f5f5f5)] ${hideThumbnail ? "hidden" : ""} ${linkedBorderHoverClasses}`}
         >
           {thumbnail ? (
             <img
@@ -162,7 +165,7 @@ const PostCardContent = React.forwardRef<HTMLDivElement, Extract<CardProps, { va
         </div>
 
         <div
-          className={`bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 rounded-b-xl ${linkedBorderHoverClasses}`}
+          className={`bg-white border border-[color:var(--color-gray-200,#e5e5e5)] flex flex-col gap-4 p-6 ${hideThumbnail ? "rounded-xl" : "rounded-b-xl"} ${linkedBorderHoverClasses}`}
         >
           {tags && tags.length > 0 && (
             <div className="flex gap-2 flex-wrap">

--- a/src/shared/ui/icons/index.tsx
+++ b/src/shared/ui/icons/index.tsx
@@ -910,3 +910,33 @@ export const CornerDownRightIcon: React.FC<IconProps> = ({ size = 20, ...props }
     />
   </svg>
 );
+
+// Google 브랜드 로고 (공식 4색 - currentColor 미적용)
+export const GoogleIcon: React.FC<IconProps> = ({ size = 20, ...props }) => (
+  <svg
+    width={size}
+    height={size}
+    viewBox="0 0 48 48"
+    xmlns="http://www.w3.org/2000/svg"
+    aria-hidden="true"
+    {...props}
+  >
+    <path
+      fill="#EA4335"
+      d="M24 9.5c3.54 0 6.71 1.22 9.21 3.6l6.85-6.85C35.9 2.38 30.47 0 24 0 14.62 0 6.51 5.38 2.56 13.22l7.98 6.19C12.43 13.72 17.74 9.5 24 9.5z"
+    />
+    <path
+      fill="#4285F4"
+      d="M46.98 24.55c0-1.57-.15-3.09-.38-4.55H24v9.02h12.94c-.58 2.96-2.26 5.48-4.78 7.18l7.73 6c4.51-4.18 7.09-10.36 7.09-17.65z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M10.53 28.59c-.48-1.45-.76-2.99-.76-4.59s.27-3.14.76-4.59l-7.98-6.19C.92 16.46 0 20.12 0 24c0 3.88.92 7.54 2.56 10.78l7.97-6.19z"
+    />
+    <path
+      fill="#34A853"
+      d="M24 48c6.48 0 11.93-2.13 15.89-5.81l-7.73-6c-2.15 1.45-4.92 2.3-8.16 2.3-6.26 0-11.57-4.22-13.47-9.91l-7.98 6.19C6.51 42.62 14.62 48 24 48z"
+    />
+    <path fill="none" d="M0 0h48v48H0z" />
+  </svg>
+);


### PR DESCRIPTION
## 🔎 What is this PR?

- 직전 릴리스 이후 `dev`에 머지된 작업 2건을 `main`으로 반영하는 릴리스 PR

---

## 📝 Changes

머지된 PR 기준 (`main..dev` 2커밋, 6파일 +71/-39)

- #178 [Fix] #167 - 로그인/회원가입(/login) 구글 로고 깨짐 및 design 대비 스펙 불일치
- #172 [Fix] #163 - 홈(/home) figma design 대비 디자인 스펙 불일치

---

## 📚 Background / Context

- 직전 릴리스(#177) 이후 `dev`에서 진행된 디자인 QA 작업을 다시 `main`으로 반영합니다.
- #178은 학생/교수 로그인의 구글 로고가 가짜 conic-gradient 원으로 그려지던 문제를 공식 4색 SVG로 교체하고, 입력 아이콘 색·크기와 탭 텍스트 크기를 스펙에 맞췄습니다.
- #172는 홈 타이포와 카드 간격, 검색 폼, 필터 버튼을 스펙에 맞추고, 히어로와 본문 카드의 좌우 정렬을 통일했습니다.
- `main` push 시 `firebase-hosting-merge.yml`이 동작해 라이브 배포가 시작됩니다.

## ✔ Checklist

- [x] 코드는 로컬에서 정상적으로 빌드됩니다 (`pnpm build`, 정적 export 17페이지 생성 확인)
- [x] ESLint / Prettier 통과 (`pnpm lint`)
- [x] 네이밍/레이어 컨벤션 준수
- [x] 관련 문서/주석 반영 (필요 시)
- [x] 주요 로직에 테스트 또는 검증 완료 (각 PR 개별 리뷰·검증 완료, `tsc --noEmit` 클린)

---

## 🙏 Request

- 두 건 모두 화면 스펙 변경이라, 배포 후 홈과 로그인 화면을 실제 브라우저에서 한 번 확인해주시면 좋겠습니다.
